### PR TITLE
Remove redundant check

### DIFF
--- a/tasks/modules/install-waf.yml
+++ b/tasks/modules/install-waf.yml
@@ -3,7 +3,6 @@
   package:
     name: nginx-plus-module-modsecurity
     state: present
-  when: waf
 
 - name: "(Setup: NGINX Plus) Load NGINX Plus WAF Module"
   lineinfile:


### PR DESCRIPTION
The main.yml task already checks for the waf variable - adding an additional check in install-waf.yml is redundant