### PR TITLE
Replace get_url module

### DIFF
--- a/tasks/plus/setup-debian.yml
+++ b/tasks/plus/setup-debian.yml
@@ -1,11 +1,19 @@
 ---
 - name: "(Install: Debian/Ubuntu) Add NGINX Plus Repository"
-  shell: printf "deb https://plus-pkgs.nginx.com/{{ ansible_distribution|lower }} `lsb_release -cs` nginx-plus\n" | sudo tee /etc/apt/sources.list.d/nginx-plus.list
+  apt_repository:
+    repo: deb https://plus-pkgs.nginx.com/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} nginx-plus
+    filename: nginx-plus
+    update_cache: no
 
 - name: "(Install: Debian/Ubuntu) Verify NGINX Plus License"
-  get_url:
-    url: https://cs.nginx.com/static/files/90nginx
-    dest: /etc/apt/apt.conf.d/90nginx
+  blockinfile:
+    path: /etc/apt/apt.conf.d/90nginx
+    create: yes
+    block: |
+      Acquire::https::plus-pkgs.nginx.com::Verify-Peer "true";
+      Acquire::https::plus-pkgs.nginx.com::Verify-Host "true";
+      Acquire::https::plus-pkgs.nginx.com::SslCert     "/etc/ssl/nginx/nginx-repo.crt";
+      Acquire::https::plus-pkgs.nginx.com::SslKey      "/etc/ssl/nginx/nginx-repo.key";
 
 - name: "(Install: Debian/Ubuntu) Update APT Cache"
   apt:

--- a/tasks/plus/setup-freebsd.yml
+++ b/tasks/plus/setup-freebsd.yml
@@ -1,8 +1,14 @@
 ---
 - name: "(Install: FreeBSD) Add NGINX Plus Repository"
-  get_url:
-    url: https://cs.nginx.com/static/files/nginx-plus.conf
-    dest: /etc/pkg/nginx-plus.conf
+  blockinfile:
+    path: /etc/pkg/nginx-plus.conf
+    create: yes
+    block: |
+      nginx-plus: {
+      URL: pkg+https://plus-pkgs.nginx.com/freebsd/${ABI}/latest
+      ENABLED: yes
+      MIRROR_TYPE: SRV
+      }
 
 - name: "(Install: FreeBSD) Verify NGINX Plus License"
   blockinfile:

--- a/tasks/plus/setup-redhat.yml
+++ b/tasks/plus/setup-redhat.yml
@@ -19,7 +19,24 @@
     version: "amazon"
   when: ansible_distribution == "Amazon"
 
-- name: "(Install: CentOS/RedHat/Amazon Linux/Oracle Linux) Add NGINX Plus Repository"
-  get_url:
-    url: https://cs.nginx.com/static/files/nginx-plus-{{ version }}.repo
-    dest: /etc/yum.repos.d/nginx-plus-{{ version }}.repo
+- name: "(Install: CentOS/RedHat/Oracle Linux) Add NGINX Plus Repository"
+  yum_repository:
+    name: nginx-plus
+    baseurl: https://plus-pkgs.nginx.com/centos/{{ version }}/$basearch/
+    description: NGINX Plus Repository
+    sslclientcert: /etc/ssl/nginx/nginx-repo.crt
+    sslclientkey: /etc/ssl/nginx/nginx-repo.key
+    enabled: yes
+    gpgcheck: yes
+  when: ansible_distribution != "Amazon"
+
+- name: "(Install: Amazon Linux) Add NGINX Plus Repository"
+  yum_repository:
+    name: nginx-plus
+    baseurl: https://plus-pkgs.nginx.com/amzn/$releasever/$basearch
+    description: NGINX Plus Repository
+    sslclientcert: /etc/ssl/nginx/nginx-repo.crt
+    sslclientkey: /etc/ssl/nginx/nginx-repo.key
+    enabled: yes
+    gpgcheck: yes
+  when: ansible_distribution == "Amazon"


### PR DESCRIPTION
The get_url module has python 2.7 dependencies. This causes errors on distros that have strict python 2.6 dependencies. Replacing the get_url module with a hardcoded code block using the blockinfile module circumvents these errors.