### PR TITLE
Implement FreeBSD support for NGINX Open Source

### DIFF
--- a/tasks/opensource/install-oss.yml
+++ b/tasks/opensource/install-oss.yml
@@ -19,7 +19,7 @@
   notify: "(Handler: All OSs) Start NGINX"
 
 - name: "(Install: FreeBSD) Install NGINX"
-  package:
+  portinstall:
     name: nginx
     state: present
   when: ansible_os_family == "FreeBSD"

--- a/tasks/opensource/install-oss.yml
+++ b/tasks/opensource/install-oss.yml
@@ -8,8 +8,19 @@
 - import_tasks: setup-suse.yml
   when: ansible_os_family == "Suse"
 
-- name: "(Install: All OSs) Install NGINX"
+- import_tasks: setup-freebsd.yml
+  when: ansible_os_family == "FreeBSD"
+
+- name: "(Install: Debian/Ubuntu/CentOS/RedHat) Install NGINX"
   package:
     name: nginx
     state: present
+  when: ansible_os_family != "FreeBSD"
+  notify: "(Handler: All OSs) Start NGINX"
+
+- name: "(Install: FreeBSD) Install NGINX"
+  package:
+    name: nginx
+    state: present
+  when: ansible_os_family == "FreeBSD"
   notify: "(Handler: All OSs) Start NGINX"

--- a/tasks/opensource/setup-freebsd.yml
+++ b/tasks/opensource/setup-freebsd.yml
@@ -1,0 +1,10 @@
+---
+- name: "(Install: FreeBSD) Fetch Ports"
+  command: portsnap fetch --interactive
+  args:
+    creates: /var/db/portsnap/INDEX
+
+- name: "(Install: FreeBSD) Extract Ports"
+  command: portsnap extract
+  args:
+    creates: /usr/ports


### PR DESCRIPTION
Use FreeBSD ports instead of pkgng to fetch the latest version of NGINX Open Source