### PR TITLE
Update install-prerequisites.yml

### DIFF
--- a/tasks/prerequisites/install-prerequisites.yml
+++ b/tasks/prerequisites/install-prerequisites.yml
@@ -1,3 +1,2 @@
 ---
 - import_tasks: setup-debian.yml
-  when: ansible_os_family == "Debian"


### PR DESCRIPTION
In order to avoid a extra call, move the next line, to control the first task on the tasks/main.yml
when: ansible_os_family == "Debian"