### PR TITLE
[Issue#54] Start NGINX handler was corrected

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,7 @@
   service:
     name: nginx
     state: started
+    enabled: yes
 
 - name: "(Handler: All OSs) Reload NGINX"
   service:


### PR DESCRIPTION
- "enabled:yes" directive was added to Start NGINX handler

https://github.com/nginxinc/ansible-role-nginx/issues/54
