### PR TITLE
fix `[WARNING]: Ignoring invalid attribute: Name`

### DIFF
--- a/tasks/prerequisites/setup-debian.yml
+++ b/tasks/prerequisites/setup-debian.yml
@@ -1,5 +1,5 @@
 ---
-- Name: "(Install: Debian/Ubuntu) Install Required Debian and Ubuntu Dependencies"
+- name: "(Install: Debian/Ubuntu) Install Required Debian and Ubuntu Dependencies"
   apt:
     name: "{{ item }}"
   with_items:


### PR DESCRIPTION
When install nginx in Ubuntu-18.04, a warning will happen 
![image](https://user-images.githubusercontent.com/39730824/44454025-060c2b00-a62d-11e8-99f9-e1d8d77b29a0.png)
this PR will fix the warning. 
