### PR TITLE
Allow setting a custom main template file

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ nginx_stream_push_location: conf/stream/*.conf
 # Configuration variables to create a templated NGINX configuration.
 # Defaults are the values found in a fresh NGINX installation.
 nginx_main_template_enable: false
+nginx_main_template_name: nginx.conf.j2
 nginx_main_template_user: nginx
 nginx_main_template_worker_processes: auto
 nginx_main_template_error_level: warn

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -99,6 +99,7 @@ nginx_stream_push_location: conf/stream/*.conf
 # Configuration variables to create a templated NGINX configuration.
 # Defaults are the values found in a fresh NGINX installation.
 nginx_main_template_enable: false
+nginx_main_template_name: nginx.conf.j2
 nginx_main_template_user: nginx
 nginx_main_template_worker_processes: auto
 nginx_main_template_error_level: warn

--- a/tasks/conf/template-config.yml
+++ b/tasks/conf/template-config.yml
@@ -1,7 +1,7 @@
 ---
 - name: "(Setup: All NGINX) Dynamically Generate NGINX Main Configuration File"
   template:
-    src: nginx.conf.j2
+    src: "{{ nginx_main_template_name }}"
     dest: /etc/nginx/nginx.conf
     backup: yes
   when: nginx_main_template_enable


### PR DESCRIPTION
This enables what I discussed in [this issue comment](https://github.com/nginxinc/ansible-role-nginx/issues/7#issuecomment-425873311).

With this, you can add a custom `templates/my-nginx-conf.j2` file, then set `nginx_main_template_name: my-nginx-conf.j2` to gain full control over the templated `nginx.conf`.

This is fully backward compatible and opt-in.