### PR TITLE
Allow setting a passive health checks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,6 +182,7 @@ nginx_http_template:
             address: localhost
             port: 8081
             weight: 1
+            health_check: max_fails=1 fail_timeout=10s
 
 # Enable creating dynamic templated NGINX stream configuration files.
 nginx_stream_template_enable: false

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -4,12 +4,13 @@ upstream {{ item.value.upstreams[upstream].name }} {
     {{ item.value.upstreams[upstream].lb_method }};
     zone {{ item.value.upstreams[upstream].zone_name }} {{ item.value.upstreams[upstream].zone_size }};
 {% for server in item.value.upstreams[upstream].servers %}
-    server {{ item.value.upstreams[upstream].servers[server].address }}:{{ item.value.upstreams[upstream].servers[server].port }} weight={{ item.value.upstreams[upstream].servers[server].weight|default("1") }};
+    server {{ item.value.upstreams[upstream].servers[server].address }}:{{ item.value.upstreams[upstream].servers[server].port }} weight={{ item.value.upstreams[upstream].servers[server].weight|default("1") }} {{ item.value.upstreams[upstream].servers[server].health_check|default("") }};
 {% endfor %}
 {% if item.value.upstreams[upstream].sticky_cookie %}
     sticky cookie srv_id expires=1h  path=/;
 {% endif %}
 }
+
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Enable setting passive health checks by vars (last line)
```nginx_http_template_enable: false
nginx_http_template:
  default:
    template_file: http/default.conf.j2
    conf_file_name: default.conf
    conf_file_location: /etc/nginx/conf.d/
    port: 8081
    server_name: localhost
    error_page: /usr/share/nginx/html
    upstreams:
      upstream1:
        name: backend
        lb_method: least_conn
        zone_name: backend
        zone_size: 64k
        sticky_cookie: false
        servers:
          server1:
            address: localhost
            port: 8081
            weight: 1
            health_check: max_fails=3 fail_timeout=5s