### PR TITLE
Enable autoindex in http, server and location namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ nginx_main_template:
     rate_limit: false
     keyval: false
   stream_enable: false
+  http_global_autoindex: false
 
 # Enable creating dynamic templated NGINX HTTP configuration files.
 # Defaults will not produce a valid configuration. Instead they are meant to showcase
@@ -327,6 +328,7 @@ nginx_http_template:
     port: 8081
     server_name: localhost
     error_page: /usr/share/nginx/html
+    autoindex: false
     ssl:
       cert: ssl/default.crt
       key: ssl/default.key
@@ -336,6 +338,7 @@ nginx_http_template:
           location: /
           html_file_location: /usr/share/nginx/html
           html_file_name: index.html
+          autoindex: false
       http_demo_conf: false
     load_balancer:
       locations:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -161,6 +161,7 @@ nginx_http_template:
     port: 8081
     server_name: localhost
     error_page: /usr/share/nginx/html
+    autoindex: false
     ssl:
       cert: ssl/default.crt
       key: ssl/default.key

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -145,6 +145,7 @@ nginx_main_template:
     rate_limit: false
     keyval: false
   stream_enable: false
+  http_global_autoindex: false
 
 # Enable creating dynamic templated NGINX HTTP configuration files.
 # Defaults will not produce a valid configuration. Instead they are meant to showcase
@@ -169,6 +170,7 @@ nginx_http_template:
           location: /
           html_file_location: /usr/share/nginx/html
           html_file_name: index.html
+          autoindex: false
       http_demo_conf: false
     load_balancer:
       locations:

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -43,6 +43,9 @@ server {
     location {{ item.value.web_server.locations[location].location }} {
         root   {{ item.value.web_server.locations[location].html_file_location }};
         index  {{ item.value.web_server.locations[location].html_file_name }};
+{% if item.value.web_server.locations[location].autoindex %}
+        autoindex on;
+{% endif %}
     }
 {% endfor %}
 {% if item.value.web_server.http_demo_conf %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -23,6 +23,9 @@ server {
     listen {{ item.value.port }};
 {% endif %}
     server_name {{ item.value.server_name }};
+{% if item.value.autoindex %}
+    autoindex on;
+{% endif %}
 {% if item.value.load_balancer is defined %}
 {% for location in item.value.load_balancer.locations %}
     location {{ item.value.load_balancer.locations[location].location }} {

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -36,6 +36,9 @@ http {
     keyval_zone zone={{nginx_main_template.http_settings.keyval.zone}}:32k state=one.keyval;
     keyval $arg_text $text zone=one;
 {% endif %}
+{% if nginx_main_template.http_global_autoindex %}
+    autoindex on;
+{% endif %}
     include /etc/nginx/conf.d/*.conf;
 }
 {% endif %}

--- a/tests/playbooks/nginx-template.yml
+++ b/tests/playbooks/nginx-template.yml
@@ -20,4 +20,5 @@
               location: /
               html_file_location: /usr/share/nginx/html
               html_file_name: index.html
+              autoindex: true
           http_demo_conf: false

--- a/tests/playbooks/nginx-template.yml
+++ b/tests/playbooks/nginx-template.yml
@@ -20,5 +20,5 @@
               location: /
               html_file_location: /usr/share/nginx/html
               html_file_name: index.html
-              autoindex: true
+              autoindex: false
           http_demo_conf: false

--- a/tests/playbooks/nginx-template.yml
+++ b/tests/playbooks/nginx-template.yml
@@ -14,6 +14,7 @@
         port: 80
         server_name: localhost
         error_page: /usr/share/nginx/html
+        autoindex: false
         web_server:
           locations:
             default:


### PR DESCRIPTION
Added variables and jinja conditions to enable autoindex in http, server and location namespaces according to issue #74 