### PR TITLE
Ignore undefined values for autoindex and health check

### DIFF
--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -23,7 +23,7 @@ server {
     listen {{ item.value.port }};
 {% endif %}
     server_name {{ item.value.server_name }};
-{% if item.value.autoindex %}
+{% if item.value.autoindex is defined and item.value.autoindex %}
     autoindex on;
 {% endif %}
 {% if item.value.load_balancer is defined %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -30,7 +30,7 @@ server {
 {% for location in item.value.load_balancer.locations %}
     location {{ item.value.load_balancer.locations[location].location }} {
         proxy_pass http://{{ item.value.load_balancer.locations[location].proxy_pass }};
-{% if item.value.load_balancer.health_check_plus %}
+{% if item.value.load_balancer.health_check_plus is defined and item.value.load_balancer.health_check_plus %}
         health_check;
 {% endif %}
         proxy_set_header Host $host;


### PR DESCRIPTION
The autoindex and health_check values are not necessary so having to specify them as false in your playbook is redundant. This checks if they are defined and true before writing the config lines.