### PR TITLE
Add ansible_managed to templates

### DIFF
--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 {% if item.value.upstreams is defined %}
 {% for upstream in item.value.upstreams %}
 upstream {{ item.value.upstreams[upstream].name }} {
@@ -8,7 +10,6 @@ upstream {{ item.value.upstreams[upstream].name }} {
 {% endfor %}
 {% if item.value.upstreams[upstream].sticky_cookie %}
     sticky cookie srv_id expires=1h  path=/;
-# {{ ansible_managed }}
 
 {% endif %}
 }

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -10,7 +10,6 @@ upstream {{ item.value.upstreams[upstream].name }} {
 {% endfor %}
 {% if item.value.upstreams[upstream].sticky_cookie %}
     sticky cookie srv_id expires=1h  path=/;
-
 {% endif %}
 }
 

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -8,6 +8,8 @@ upstream {{ item.value.upstreams[upstream].name }} {
 {% endfor %}
 {% if item.value.upstreams[upstream].sticky_cookie %}
     sticky cookie srv_id expires=1h  path=/;
+# {{ ansible_managed }}
+
 {% endif %}
 }
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 user  {{ nginx_main_template.user }};
 worker_processes  {{ nginx_main_template.worker_processes }};
 

--- a/templates/stream/stream.conf.j2
+++ b/templates/stream/stream.conf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 server {
     listen {{ nginx_stream_template_listen }};
 }

--- a/templates/www/index.html.j2
+++ b/templates/www/index.html.j2
@@ -1,3 +1,5 @@
+<!-- {{ ansible_managed }} -->
+
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
Best practice is that all templates handled by Ansible should have {{ ansible_managed }} at the top so everyone knows local changes may be overwritten.