### PR TITLE
Add support for enabling an http to https redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ nginx_http_template:
     port: 8081
     server_name: localhost
     error_page: /usr/share/nginx/html
+    redirect: false
     autoindex: false
     ssl:
       cert: ssl/default.crt

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -161,6 +161,7 @@ nginx_http_template:
     port: 8081
     server_name: localhost
     error_page: /usr/share/nginx/html
+    redirect: false
     autoindex: false
     ssl:
       cert: ssl/default.crt

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -26,6 +26,9 @@ server {
 {% if item.value.autoindex %}
     autoindex on;
 {% endif %}
+{% if item.value.redirect is defined and item.value.redirect %}}
+    return 301 https://{{ item.value.server_name }}$request_uri;
+{% endif%}}
 {% if item.value.load_balancer is defined %}
 {% for location in item.value.load_balancer.locations %}
     location {{ item.value.load_balancer.locations[location].location }} {

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -28,7 +28,7 @@ server {
 {% endif %}
 {% if item.value.redirect is defined and item.value.redirect %}}
     return 301 https://{{ item.value.server_name }}$request_uri;
-{% endif%}}
+{% endif%}
 {% if item.value.load_balancer is defined %}
 {% for location in item.value.load_balancer.locations %}
     location {{ item.value.load_balancer.locations[location].location }} {

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -26,7 +26,7 @@ server {
 {% if item.value.autoindex %}
     autoindex on;
 {% endif %}
-{% if item.value.redirect is defined and item.value.redirect %}}
+{% if item.value.redirect is defined and item.value.redirect %}
     return 301 https://{{ item.value.server_name }}$request_uri;
 {% endif%}
 {% if item.value.load_balancer is defined %}


### PR DESCRIPTION
A common function is to have a port server listening to http and redirect to https.

This adds a simple common redirect option. I don't know if you have more detailed plans for this option. 