### PR TITLE
adds parameter support for ssl listening

### DIFF
--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -16,7 +16,11 @@ upstream {{ item.value.upstreams[upstream].name }} {
 
 server {
 {% if item.value.ssl is defined %}
+{% if item.value.port is defined %}
+    listen {{ item.value.port }};
+{% else %}
     listen 443 ssl;
+{% endif %}
     ssl_certificate {{ nginx_ssl_crt_upload_dest }}/{{ item.value.ssl.cert }};
     ssl_certificate_key {{ nginx_ssl_key_upload_dest }}/{{ item.value.ssl.key }};
 {% else %}


### PR DESCRIPTION
This merge request allows using custom parameters in an SSL listen directive.

e.g. [default_server] [ssl] [http2 | spdy] [proxy_protocol] [setfib=number] [fastopen=number] [backlog=number] [rcvbuf=size] [sndbuf=size] [accept_filter=filter] [deferred] [bind] [ipv6only=on|off] [reuseport] ...

http://nginx.org/en/docs/http/ngx_http_core_module.html#listen

best regards