### PR TITLE
Websocket support enabled for reverse proxy locations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,8 +350,8 @@ nginx_http_template:
         backend:
           location: /
           proxy_pass: http://backend
+          websocket: false
       health_check_plus: false
-      websocket: false
     upstreams:
       upstream1:
         name: backend

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ nginx_http_template:
           location: /
           proxy_pass: http://backend
       health_check_plus: false
+      websocket: false
     upstreams:
       upstream1:
         name: backend

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,6 +182,7 @@ nginx_http_template:
           location: /
           proxy_pass: http://backend
       health_check_plus: false
+      websocket: false
     upstreams:
       upstream1:
         name: backend

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -181,8 +181,8 @@ nginx_http_template:
         backend:
           location: /
           proxy_pass: http://backend
+          websocket: false
       health_check_plus: false
-      websocket: false
     upstreams:
       upstream1:
         name: backend

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -42,6 +42,10 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+{% if item.value.reverse_proxy.websocket is defined and item.value.reverse_proxy.websocket %}
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+{% endif %}
     }
 
 {% endfor %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -42,7 +42,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-{% if item.value.reverse_proxy.websocket is defined and item.value.reverse_proxy.websocket %}
+{% if item.value.reverse_proxy.locations[location].websocket is defined and item.value.reverse_proxy.locations[location].websocket %}
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
 {% endif %}


### PR DESCRIPTION
https://www.nginx.com/blog/websocket-nginx

I couldn't really decide what was a good position of the websocket key so I just put it somewhere. I will ofcourse move it or change name of it based on the comments on this PR.