### PR TITLE
Support multi-line ansible_managed messages

### DIFF
--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% if item.value.upstreams is defined %}
 {% for upstream in item.value.upstreams %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 user  {{ nginx_main_template.user }};
 worker_processes  {{ nginx_main_template.worker_processes }};

--- a/templates/stream/default.conf.j2
+++ b/templates/stream/default.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% if item.value.upstreams is defined %}
 {% for upstream in item.value.upstreams %}
 upstream {{ item.value.upstreams[upstream].name }} {


### PR DESCRIPTION
This'll allow you to use a multi-line ansible_managed message. This chain is not compatible with ansible 1.x, but that's already broken with the use of 'become' instead of 'sudo' likely among other things.