### PR TITLE
proxy_http_version should be set for websockets

### DIFF
--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -156,6 +156,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 {% if item.value.reverse_proxy.locations[location].websocket is defined and item.value.reverse_proxy.locations[location].websocket %}
+        proxy_http_version 1.1;        
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
 {% endif %}


### PR DESCRIPTION
Hi,

As stated in the official documentation (http://nginx.org/en/docs/http/websocket.html), proxy_http_version should be used.

I had a usecase (proxying apicurio-studio) where it was required to work properly.

Julien