### PR TITLE
Make starting the nginx service optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ This role has multiple variables. The defaults for all these variables are the f
 # Default is true.
 nginx_enable: true
 
+# Start NGINX service.
+# Default is true.
+nginx_start: true
+
 # Print NGINX configuration file to terminal after executing playbook.
 nginx_debug_output: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,10 @@
 # Default is true.
 nginx_enable: true
 
+# Start NGINX service.
+# Default is true
+nginx_start: true
+
 # Print NGINX configuration file to terminal after executing playbook.
 nginx_debug_output: false
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,30 +4,36 @@
     name: nginx
     state: started
     enabled: yes
+  when: nginx_start
 
 - name: "(Handler: All OSs) Reload NGINX"
   service:
     name: nginx
     state: reloaded
+  when: nginx_start
 
 - name: "(Handler: All OSs) Start NGINX Amplify Agent"
   service:
     name: amplify-agent
     state: started
+  when: nginx_start
 
 - name: "(Handler: All OSs) Start NGINX Controller Agent"
   service:
     name: controller-agent
     state: started
+  when: nginx_start
 
 - name: "(Handler: Debian/Ubuntu/CentOS/RedHat) Start NGINX Unit"
   service:
     name: unit
     state: started
     enabled: yes
+  when: nginx_start
 
 - name: "(Handler: FreeBSD) Start NGINX Unit"
   service:
     name: unitd
     state: started
     enabled: yes
+  when: nginx_start


### PR DESCRIPTION
Some sites may prefer to start nginx manually, or via a different method from the `service` command.