### PR TITLE
Allow auth basic to be added to global (server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ nginx_http_template:
     root: /usr/share/nginx/html
     https_redirect: false
     autoindex: false
+    auth_basic: null
+    auth_basic_file: null
     #auth_request: /auth
     ssl:
       cert: /etc/ssl/certs/default.crt

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ nginx_http_template:
     https_redirect: false
     autoindex: false
     auth_basic: null
-    auth_basic_file: null
+    auth_basic_user_file: null
     #auth_request: /auth
     ssl:
       cert: /etc/ssl/certs/default.crt
@@ -348,7 +348,7 @@ nginx_http_template:
           html_file_name: index.html
           autoindex: false
           auth_basic: null
-          auth_basic_file: null
+          auth_basic_user_file: null
           #auth_req: /auth
           #returns:
             #return302:
@@ -434,7 +434,7 @@ nginx_http_template:
           proxy_redirect: false
           websocket: false
           auth_basic: null
-          auth_basic_file: null
+          auth_basic_user_file: null
           #auth_req: /auth
           #returns:
             #return302:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -190,7 +190,7 @@ nginx_http_template:
           html_file_name: index.html
           autoindex: false
           auth_basic: null
-          auth_basic_file: null
+          auth_basic_user_file: null
           try_files: $uri $uri/index.html $uri.html =404
           #auth_request: /auth
           #returns:
@@ -273,7 +273,7 @@ nginx_http_template:
             - Cache-Control
           websocket: false
           auth_basic: null
-          auth_basic_file: null
+          auth_basic_user_file: null
           try_files: $uri $uri/index.html $uri.html =404
           #auth_req: /auth
           #returns:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -172,6 +172,8 @@ nginx_http_template:
     root: /usr/share/nginx/html
     https_redirect: false
     autoindex: false
+    auth_basic: null
+    auth_basic_user_file: null
     try_files: $uri $uri/index.html $uri.html =404
     #auth_request: /auth
     ssl:

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -77,8 +77,8 @@ server {
 {% if item.value.auth_basic is defined and item.value.auth_basic %}
     auth_basic "{{ item.value.auth_basic }}";
 {% endif %}
-{% if item.value.auth_basic_file is defined and item.value.auth_basic_file %}
-    auth_basic_user_file {{ item.value.auth_basic_file }};
+{% if item.value.auth_basic_user_file is defined and item.value.auth_basic_user_file %}
+    auth_basic_user_file {{ item.value.auth_basic_user_file }};
 {% endif %}
 {% if item.value.root is defined and item.value.root %}
     root {{ item.value.root }};
@@ -108,8 +108,8 @@ server {
 {% if item.value.reverse_proxy.locations[location].auth_basic is defined and item.value.reverse_proxy.locations[location].auth_basic %}
         auth_basic "{{ item.value.reverse_proxy.locations[location].auth_basic }}";
 {% endif %}
-{% if item.value.reverse_proxy.locations[location].auth_basic_file is defined and item.value.reverse_proxy.locations[location].auth_basic_file %}
-        auth_basic_user_file {{ item.value.reverse_proxy.locations[location].auth_basic_file }};
+{% if item.value.reverse_proxy.locations[location].auth_basic_user_file is defined and item.value.reverse_proxy.locations[location].auth_basic_user_file %}
+        auth_basic_user_file {{ item.value.reverse_proxy.locations[location].auth_basic_user_file }};
 {% endif %}
 {% if item.value.reverse_proxy.locations[location].returns is defined %}
 {% for code in item.value.reverse_proxy.locations[location].returns %}
@@ -235,8 +235,8 @@ server {
 {% if item.value.web_server.locations[location].auth_basic is defined and item.value.web_server.locations[location].auth_basic %}
         auth_basic "{{ item.value.web_server.locations[location].auth_basic }}";
 {% endif %}
-{% if item.value.web_server.locations[location].auth_basic_file is defined and item.value.web_server.locations[location].auth_basic_file %}
-        auth_basic_user_file {{ item.value.web_server.locations[location].auth_basic_file }};
+{% if item.value.web_server.locations[location].auth_basic_user_file is defined and item.value.web_server.locations[location].auth_basic_user_file %}
+        auth_basic_user_file {{ item.value.web_server.locations[location].auth_basic_user_file }};
 {% endif %}
 {% if item.value.web_server.locations[location].auth_request is defined %}
         auth_request {{ item.value.web_server.locations[location].auth_request }};

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -75,10 +75,10 @@ server {
 {% endif %}
     server_name {{ item.value.server_name }};
 {% if item.value.auth_basic is defined and item.value.auth_basic %}
-        auth_basic "{{ item.value.auth_basic }}";
+    auth_basic "{{ item.value.auth_basic }}";
 {% endif %}
 {% if item.value.auth_basic_file is defined and item.value.auth_basic_file %}
-        auth_basic_user_file {{ item.value.auth_basic_file }};
+    auth_basic_user_file {{ item.value.auth_basic_file }};
 {% endif %}
 {% if item.value.root is defined and item.value.root %}
     root {{ item.value.root }};

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -74,6 +74,12 @@ server {
     listen {{ item.value.port }};
 {% endif %}
     server_name {{ item.value.server_name }};
+{% if item.value.auth_basic is defined and item.value.auth_basic %}
+        auth_basic "{{ item.value.auth_basic }}";
+{% endif %}
+{% if item.value.auth_basic_file is defined and item.value.auth_basic_file %}
+        auth_basic_user_file {{ item.value.auth_basic_file }};
+{% endif %}
 {% if item.value.root is defined and item.value.root %}
     root {{ item.value.root }};
 {% endif %}


### PR DESCRIPTION
Was having an issue to make my entire site to have password protection as the template only provides 'location' level protection.

According to the official docs, we can enable http authentication on 'server' level: https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-http-basic-authentication/