### PR TITLE
Add https redirect to web_server and make optional for html file location file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ nginx_http_template:
       locations:
         default:
           location: /
+          index: index index.php index.html index.htm index.nginx-debian.html #This includes index.php as well
           html_file_location: /usr/share/nginx/html
           html_file_name: index.html
           autoindex: false
@@ -352,6 +353,17 @@ nginx_http_template:
             #return302:
               #code: 302
               #url: https://sso.somehost.local/?url=https://$http_host$request_uri
+
+        php:  #Sample for PHP or other Preprocessors
+          location: ~ \.php$ 
+          include: snippets/fastcgi-php.conf
+          fastcgi_pass: unix:/run/php/php7.0-fpm.sock
+
+        webshare: #Sample for a website to show the files you have in 'alias'
+          location: /webshare
+          alias: /usr/share/files/pishare/
+          autoindex: true
+
       http_demo_conf: false
     reverse_proxy:
       proxy_cache_path:

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ nginx_http_template:
 
         webshare: #Sample for a website to show the files you have in 'alias'
           location: /webshare
-          alias: /usr/share/files/pishare/
+          alias: /usr/share/files/webshare/
           autoindex: true
 
       http_demo_conf: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -190,7 +190,6 @@ nginx_http_template:
           html_file_location: /usr/share/nginx/html
           html_file_name: index.html
           autoindex: false
-          https_redirect: false
           auth_basic: null
           auth_basic_file: null
           try_files: $uri $uri/index.html $uri.html =404

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -170,6 +170,7 @@ nginx_http_template:
     server_name: localhost
     error_page: /usr/share/nginx/html
     root: /usr/share/nginx/html
+    index: index index.html index.htm index.nginx-debian.html
     https_redirect: false
     autoindex: false
     try_files: $uri $uri/index.html $uri.html =404
@@ -189,6 +190,7 @@ nginx_http_template:
           html_file_location: /usr/share/nginx/html
           html_file_name: index.html
           autoindex: false
+          https_redirect: false
           auth_basic: null
           auth_basic_file: null
           try_files: $uri $uri/index.html $uri.html =404

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -209,8 +209,15 @@ server {
 {% if item.value.web_server is defined %}
 {% for location in item.value.web_server.locations %}
     location {{ item.value.web_server.locations[location].location }} {
+{% if item.value.web_server.locations[location].html_file_location is defined and item.value.web_server.locations[location].html_file_location %}
         root   {{ item.value.web_server.locations[location].html_file_location }};
+{% endif %}
+{% if item.value.web_server.locations[location].html_file_name is defined and item.value.web_server.locations[location].html_file_name %}
         index  {{ item.value.web_server.locations[location].html_file_name }};
+{% endif %}
+{% if item.value.web_server.locations[location].https_redirect is defined and item.value.web_server.locations[location].https_redirect %}
+        return 301 https://{{ item.value.server_name }}$request_uri;
+{% endif %}
 {% if item.value.web_server.locations[location].autoindex %}
         autoindex on;
 {% endif %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -224,6 +224,9 @@ server {
 {% if item.value.web_server.locations[location].autoindex is defined and item.value.web_server.locations[location].autoindex %}
         autoindex on;
 {% endif %}
+{% if item.value.web_server.locations[location].alias is defined and item.value.web_server.locations[location].alias %}
+        alias {{ item.value.web_server.locations[location].alias }};
+{% endif %}
 {% if item.value.web_server.locations[location].include is defined and item.value.web_server.locations[location].include %}
         include {{ item.value.web_server.locations[location].include }};
 {% endif %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -225,7 +225,7 @@ server {
         include {{ item.value.web_server.locations[location].include }};
 {% endif %}
 {% if item.value.web_server.locations[location].fastcgi_pass is defined and item.value.web_server.locations[location].fastcgi_pass %}
-        include {{ item.value.web_server.locations[location].fastcgi_pass }};
+        fastcgi_pass {{ item.value.web_server.locations[location].fastcgi_pass }};
 {% endif %}
 {% if item.value.web_server.locations[location].try_files is defined %}
         try_files {{ item.value.web_server.locations[location].try_files }};

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -77,6 +77,9 @@ server {
 {% if item.value.root is defined and item.value.root %}
     root {{ item.value.root }};
 {% endif %}
+{% if item.value.index is defined and item.value.index %}
+    index {{ item.value.index }};
+{% endif %}
 {% if item.value.https_redirect is defined and item.value.https_redirect %}
     return 301 https://{{ item.value.server_name }}$request_uri;
 {% endif %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -218,8 +218,14 @@ server {
 {% if item.value.web_server.locations[location].https_redirect is defined and item.value.web_server.locations[location].https_redirect %}
         return 301 https://{{ item.value.server_name }}$request_uri;
 {% endif %}
-{% if item.value.web_server.locations[location].autoindex %}
+{% if item.value.web_server.locations[location].autoindex is defined and item.value.web_server.locations[location].autoindex %}
         autoindex on;
+{% endif %}
+{% if item.value.web_server.locations[location].include is defined and item.value.web_server.locations[location].include %}
+        include {{ item.value.web_server.locations[location].include }};
+{% endif %}
+{% if item.value.web_server.locations[location].fastcgi_pass is defined and item.value.web_server.locations[location].fastcgi_pass %}
+        include {{ item.value.web_server.locations[location].fastcgi_pass }};
 {% endif %}
 {% if item.value.web_server.locations[location].try_files is defined %}
         try_files {{ item.value.web_server.locations[location].try_files }};

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -156,6 +156,7 @@
               alias: /usr/share/
               html_file_location: /usr/share/nginx/html
               html_file_name: backend_index.html
+              https_redirect: false
               autoindex: false
           http_demo_conf: true
     nginx_html_demo_template_enable: true

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -153,7 +153,6 @@
           locations:
             backend_site:
               location: /
-              alias: /usr/share/
               html_file_location: /usr/share/nginx/html
               html_file_name: backend_index.html
               https_redirect: false

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -153,6 +153,7 @@
           locations:
             backend_site:
               location: /
+              alias: /usr/share/
               html_file_location: /usr/share/nginx/html
               html_file_name: backend_index.html
               autoindex: false


### PR DESCRIPTION
Scenario: I'm trying to enable lets encrypt and at the same time redirect the traffic from http to https.
However, the current setup doesn't cut it as it redirects on the root level only.

```
server {
    listen 80;
    server_name sample.com;

    location / {
        return 301 https://sample.com$request_uri;
    }
    location /.well-known/acme-challenge {
        root   /var/www/letsencrypt;
        try_files $uri $uri/ =404;
    }
```
This is the best barebone let's encrypt nginx conf file that we can have.

Additionally I've made autoindex to be optional too as it is not required.
added in fastcgi_pass and include as they are also nginx variables too.