### PR TITLE
Catch-all ("_") check for https redirect

### DIFF
--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -83,7 +83,7 @@ server {
     root {{ item.value.root }};
 {% endif %}
 {% if item.value.https_redirect is defined and item.value.https_redirect %}
-    return 301 https://{{ item.value.server_name }}$request_uri;
+    return 301 https://{% if item.value.server_name == "_" %}$host{% else %}{{ item.value.server_name }}{% endif %}$request_uri;
 {% endif %}
 {% if item.value.autoindex is defined and item.value.autoindex %}
     autoindex on;


### PR DESCRIPTION
If catch-all ("`_`") is used as `server_name`and `https_redirect` is `true`, `_` will be replaced with `$host` for `return 301`.

Ref: #137 