### PR TITLE
Add websockets configuration back to http template

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,9 +462,8 @@ nginx_http_template:
           proxy_ignore_headers:
             - Vary
             - Cache-Control
-          websocket:
-            enabled: false
-            proxy_http_version: 1.0
+          proxy_http_version: 1.0
+          websocket: false
           auth_basic: null
           auth_basic_user_file: null
           try_files: $uri $uri/index.html $uri.html =404

--- a/README.md
+++ b/README.md
@@ -462,7 +462,9 @@ nginx_http_template:
           proxy_ignore_headers:
             - Vary
             - Cache-Control
-          websocket: false
+          websocket:
+            enabled: false
+            proxy_http_version: 1.0
           auth_basic: null
           auth_basic_user_file: null
           try_files: $uri $uri/index.html $uri.html =404

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -274,7 +274,9 @@ nginx_http_template:
           proxy_ignore_headers:
             - Vary
             - Cache-Control
-          websocket: false
+          websocket:
+            enabled: false
+            proxy_http_version: 1.0
           auth_basic: null
           auth_basic_user_file: null
           try_files: $uri $uri/index.html $uri.html =404

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -274,9 +274,8 @@ nginx_http_template:
           proxy_ignore_headers:
             - Vary
             - Cache-Control
-          websocket:
-            enabled: false
-            proxy_http_version: 1.0
+          proxy_http_version: 1.0
+          websocket: false
           auth_basic: null
           auth_basic_user_file: null
           try_files: $uri $uri/index.html $uri.html =404

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -139,6 +139,10 @@ server {
 {% for header in item.value.reverse_proxy.locations[location].proxy_set_header %}
         proxy_set_header {{ item.value.reverse_proxy.locations[location].proxy_set_header[header].name }} {{ item.value.reverse_proxy.locations[location].proxy_set_header[header].value }};
 {% endfor %}
+{% if item.value.reverse_proxy.locations[location].websocket is defined and item.value.reverse_proxy.locations[location].websocket %}
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+{% endif %}
 {% endif %}
 {% if item.value.reverse_proxy.locations[location].try_files is defined %}
         try_files {{ item.value.reverse_proxy.locations[location].try_files }};

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -139,10 +139,10 @@ server {
 {% for header in item.value.reverse_proxy.locations[location].proxy_set_header %}
         proxy_set_header {{ item.value.reverse_proxy.locations[location].proxy_set_header[header].name }} {{ item.value.reverse_proxy.locations[location].proxy_set_header[header].value }};
 {% endfor %}
-{% if item.value.reverse_proxy.locations[location].websocket is defined and item.value.reverse_proxy.locations[location].websocket.enabled %}
-{% if item.value.reverse_proxy.locations[location].websocket.proxy_http_version is defined %}
-        proxy_http_version {{ item.value.reverse_proxy.locations[location].websocket.proxy_http_version }};
+{% if item.value.reverse_proxy.locations[location].proxy_http_version is defined %}
+        proxy_http_version {{ item.value.reverse_proxy.locations[location].proxy_http_version }};
 {% endif %}
+{% if item.value.reverse_proxy.locations[location].websocket is defined and item.value.reverse_proxy.locations[location].websocket %}
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
 {% endif %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -139,7 +139,10 @@ server {
 {% for header in item.value.reverse_proxy.locations[location].proxy_set_header %}
         proxy_set_header {{ item.value.reverse_proxy.locations[location].proxy_set_header[header].name }} {{ item.value.reverse_proxy.locations[location].proxy_set_header[header].value }};
 {% endfor %}
-{% if item.value.reverse_proxy.locations[location].websocket is defined and item.value.reverse_proxy.locations[location].websocket %}
+{% if item.value.reverse_proxy.locations[location].websocket is defined and item.value.reverse_proxy.locations[location].websocket.enabled %}
+{% if item.value.reverse_proxy.locations[location].websocket.proxy_http_version is defined %}
+        proxy_http_version {{ item.value.reverse_proxy.locations[location].websocket.proxy_http_version }};
+{% endif %}
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
 {% endif %}


### PR DESCRIPTION
Add websockets configuration back to http template file.
I also implemented the changes from #111 and made `proxy_http_version` configurable.
By default (when the variable is not defined) it is not added to the configuration.

Ref: #139 