### PR TITLE
Add `add_header` support for either `server` and `location` block

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,15 @@ nginx_http_template:
     auth_basic_user_file: null
     try_files: $uri $uri/index.html $uri.html =404
     #auth_request: /auth
+    add_headers:
+      strict_transport_security:
+        name: Strict-Transport-Security
+        value: max-age=15768000; includeSubDomains
+        always: true
+      #header_n:
+        #name: Header-X
+        #value: Value-X
+        #always: false
     ssl:
       cert: /etc/ssl/certs/default.crt
       key: /etc/ssl/private/default.key
@@ -377,6 +386,15 @@ nginx_http_template:
       locations:
         default:
           location: /
+          add_headers:
+            strict_transport_security:
+              name: Strict-Transport-Security
+              value: max-age=15768000; includeSubDomains
+              always: true
+            #header_n:
+              #name: Header-X
+              #value: Value-X
+              #always: false
           html_file_location: /usr/share/nginx/html
           html_file_name: index.html
           autoindex: false
@@ -412,6 +430,15 @@ nginx_http_template:
       locations:
         backend:
           location: /
+          add_headers:
+            strict_transport_security:
+              name: Strict-Transport-Security
+              value: max-age=15768000; includeSubDomains
+              always: true
+            #header_n:
+              #name: Header-X
+              #value: Value-X
+              #always: false
           proxy_connect_timeout: null
           proxy_pass: http://backend
           #proxy_pass_request_body: off

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ nginx_http_template:
         name: Strict-Transport-Security
         value: max-age=15768000; includeSubDomains
         always: true
-      #header_n:
+      #header_name:
         #name: Header-X
         #value: Value-X
         #always: false
@@ -391,7 +391,7 @@ nginx_http_template:
               name: Strict-Transport-Security
               value: max-age=15768000; includeSubDomains
               always: true
-            #header_n:
+            #header_name:
               #name: Header-X
               #value: Value-X
               #always: false
@@ -435,7 +435,7 @@ nginx_http_template:
               name: Strict-Transport-Security
               value: max-age=15768000; includeSubDomains
               always: true
-            #header_n:
+            #header_name:
               #name: Header-X
               #value: Value-X
               #always: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -177,6 +177,15 @@ nginx_http_template:
     auth_basic_user_file: null
     try_files: $uri $uri/index.html $uri.html =404
     #auth_request: /auth
+    add_headers:
+      strict_transport_security:
+        name: Strict-Transport-Security
+        value: max-age=15768000; includeSubDomains
+        always: true
+      #header_n:
+        #name: Header-X
+        #value: Value-X
+        #always: false
     ssl:
       cert: /etc/ssl/certs/default.crt
       key: /etc/ssl/private/default.key
@@ -189,6 +198,15 @@ nginx_http_template:
       locations:
         default:
           location: /
+          add_headers:
+            strict_transport_security:
+              name: Strict-Transport-Security
+              value: max-age=15768000; includeSubDomains
+              always: true
+            #header_n:
+              #name: Header-X
+              #value: Value-X
+              #always: false
           html_file_location: /usr/share/nginx/html
           html_file_name: index.html
           autoindex: false
@@ -224,6 +242,15 @@ nginx_http_template:
       locations:
         backend:
           location: /
+          add_headers:
+            strict_transport_security:
+              name: Strict-Transport-Security
+              value: max-age=15768000; includeSubDomains
+              always: true
+            #header_n:
+              #name: Header-X
+              #value: Value-X
+              #always: false
           proxy_connect_timeout: null
           proxy_pass: http://backend
           #proxy_pass_request_body: off

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,7 +182,7 @@ nginx_http_template:
         name: Strict-Transport-Security
         value: max-age=15768000; includeSubDomains
         always: true
-      #header_n:
+      #header_name:
         #name: Header-X
         #value: Value-X
         #always: false
@@ -203,7 +203,7 @@ nginx_http_template:
               name: Strict-Transport-Security
               value: max-age=15768000; includeSubDomains
               always: true
-            #header_n:
+            #header_name:
               #name: Header-X
               #value: Value-X
               #always: false
@@ -247,7 +247,7 @@ nginx_http_template:
               name: Strict-Transport-Security
               value: max-age=15768000; includeSubDomains
               always: true
-            #header_n:
+            #header_name:
               #name: Header-X
               #value: Value-X
               #always: false

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -73,6 +73,11 @@ server {
     listen {{ item.value.port }};
 {% endif %}
     server_name {{ item.value.server_name | default('localhost') }};
+{% if item.value.add_headers is defined %}
+{% for header in item.value.add_headers %}
+    add_header {{ item.value.add_headers[header].name }} "{{ item.value.add_headers[header].value }}"{% if item.value.add_headers[header].always is defined and item.value.add_headers[header].always %} always{% endif %};
+{% endfor %}
+{% endif %}
 {% if item.value.auth_basic is defined and item.value.auth_basic %}
     auth_basic "{{ item.value.auth_basic }}";
 {% endif %}
@@ -100,6 +105,11 @@ server {
     location {{ item.value.reverse_proxy.locations[location].location }} {
 {% if item.value.reverse_proxy.locations[location].internal is sameas true %}
         internal;
+{% endif %}
+{% if item.value.reverse_proxy.locations[location].add_headers is defined %}
+{% for header in item.value.reverse_proxy.locations[location].add_headers %}
+        add_header {{ item.value.reverse_proxy.locations[location].add_headers[header].name }} "{{ item.value.reverse_proxy.locations[location].add_headers[header].value }}"{% if item.value.reverse_proxy.locations[location].add_headers[header].always is defined and item.value.reverse_proxy.locations[location].add_headers[header].always %} always{% endif %};
+{% endfor %}
 {% endif %}
 {% if item.value.reverse_proxy.locations[location].auth_request is defined %}
         auth_request {{ item.value.reverse_proxy.locations[location].auth_request }};
@@ -221,6 +231,11 @@ server {
 {% endif %}
 {% if item.value.web_server.locations[location].try_files is defined %}
         try_files {{ item.value.web_server.locations[location].try_files }};
+{% endif %}
+{% if item.value.web_server.locations[location].add_headers is defined %}
+{% for header in item.value.web_server.locations[location].add_headers %}
+        add_header {{ item.value.web_server.locations[location].add_headers[header].name }} "{{ item.value.web_server.locations[location].add_headers[header].value }}"{% if item.value.web_server.locations[location].add_headers[header].always is defined and item.value.web_server.locations[location].add_headers[header].always %} always{% endif %};
+{% endfor %}
 {% endif %}
 {% if item.value.web_server.locations[location].returns is defined %}
 {% for code in item.value.web_server.locations[location].returns %}


### PR DESCRIPTION
Add support for adding headers either in the server or in the location (either web_server or revers_proxy) block.