### PR TITLE
Add directives to use OCSP Stapling

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,9 @@ nginx_http_template:
       ciphers: HIGH:!aNULL:!MD5
       session_cache: none
       session_timeout: 5m
+      trusted_cert: /etc/ssl/certs/root_CA_cert_plus_intermediates.crt
+      stapling: true
+      stapling_verify: true
     web_server:
       locations:
         default:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -185,6 +185,9 @@ nginx_http_template:
       ciphers: HIGH:!aNULL:!MD5
       session_cache: none
       session_timeout: 5m
+      trusted_cert: /etc/ssl/certs/root_CA_cert_plus_intermediates.crt
+      stapling: true
+      stapling_verify: true
     web_server:
       locations:
         default:

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -54,6 +54,9 @@ server {
     listen {{ item.value.port }} ssl;
     ssl_certificate {{ item.value.ssl.cert }};
     ssl_certificate_key {{ item.value.ssl.key }};
+{% if item.value.ssl.trusted_cert is defined %}
+    ssl_trusted_certificate {{ item.value.ssl.trusted_cert }};
+{% endif %}
 {% if item.value.ssl.dhparam is defined %}
     ssl_dhparam {{ item.value.ssl.dhparam }};
 {% endif %}
@@ -68,6 +71,12 @@ server {
 {% endif %}
 {% if item.value.ssl.session_timeout is defined and item.value.ssl.session_timeout %}
     ssl_session_timeout {{ item.value.ssl.session_timeout }};
+{% endif %}
+{% if item.value.ssl.stapling is defined and item.value.ssl.stapling %}
+    ssl_stapling on;
+{% endif %}
+{% if item.value.ssl.stapling_verify is defined and item.value.ssl.stapling_verify %}
+    ssl_stapling_verify on;
 {% endif %}
 {% else %}
     listen {{ item.value.port }};


### PR DESCRIPTION
Add `ssl_trusted_certificate`, `ssl_stapling`, `ssl_stapling_verify` to configure OCSP stapling.