### PR TITLE
Add directive ssl_prefer_server_ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ nginx_http_template:
       dhparam: /etc/ssl/private/dh_param.pem
       protocols: TLSv1 TLSv1.1 TLSv1.2
       ciphers: HIGH:!aNULL:!MD5
+      prefer_server_ciphers: true
       session_cache: none
       session_timeout: 5m
     web_server:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -183,6 +183,7 @@ nginx_http_template:
       dhparam: /etc/ssl/private/dh_param.pem
       protocols: TLSv1 TLSv1.1 TLSv1.2
       ciphers: HIGH:!aNULL:!MD5
+      prefer_server_ciphers: true
       session_cache: none
       session_timeout: 5m
     web_server:

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -63,6 +63,9 @@ server {
 {% if item.value.ssl.ciphers is defined and item.value.ssl.ciphers %}
     ssl_ciphers {{ item.value.ssl.ciphers }};
 {% endif %}
+{% if item.value.ssl.prefer_server_ciphers is defined and item.value.ssl.prefer_server_ciphers %}
+    ssl_prefer_server_ciphers on;
+{% endif %}
 {% if item.value.ssl.session_cache is defined and item.value.ssl.session_cache %}
     ssl_session_cache {{ item.value.ssl.session_cache }};
 {% endif %}


### PR DESCRIPTION
Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols.