### PR TITLE
Add proxy_hide-header directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ nginx_http_template:
     auth_basic_user_file: null
     try_files: $uri $uri/index.html $uri.html =404
     #auth_request: /auth
+    proxy_hide_headers: [] # A list of headers which shouldn't be passed to the application
     ssl:
       cert: /etc/ssl/certs/default.crt
       key: /etc/ssl/private/default.key
@@ -377,6 +378,7 @@ nginx_http_template:
       locations:
         default:
           location: /
+          proxy_hide_headers: [] # A list of headers which shouldn't be passed to the application
           html_file_location: /usr/share/nginx/html
           html_file_name: index.html
           autoindex: false
@@ -412,6 +414,7 @@ nginx_http_template:
       locations:
         backend:
           location: /
+          proxy_hide_headers: [] # A list of headers which shouldn't be passed to the application
           proxy_connect_timeout: null
           proxy_pass: http://backend
           #proxy_pass_request_body: off

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -177,7 +177,7 @@ nginx_http_template:
     auth_basic_user_file: null
     try_files: $uri $uri/index.html $uri.html =404
     #auth_request: /auth
-    proxy_hide_headers: []
+    proxy_hide_headers: [] # A list of headers which shouldn't be passed to the application
     ssl:
       cert: /etc/ssl/certs/default.crt
       key: /etc/ssl/private/default.key
@@ -190,7 +190,7 @@ nginx_http_template:
       locations:
         default:
           location: /
-          proxy_hide_headers: []
+          proxy_hide_headers: [] # A list of headers which shouldn't be passed to the application
           html_file_location: /usr/share/nginx/html
           html_file_name: index.html
           autoindex: false
@@ -226,7 +226,7 @@ nginx_http_template:
       locations:
         backend:
           location: /
-          proxy_hide_headers: []
+          proxy_hide_headers: [] # A list of headers which shouldn't be passed to the application
           proxy_connect_timeout: null
           proxy_pass: http://backend
           #proxy_pass_request_body: off

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -177,6 +177,7 @@ nginx_http_template:
     auth_basic_user_file: null
     try_files: $uri $uri/index.html $uri.html =404
     #auth_request: /auth
+    proxy_hide_headers: []
     ssl:
       cert: /etc/ssl/certs/default.crt
       key: /etc/ssl/private/default.key
@@ -189,6 +190,7 @@ nginx_http_template:
       locations:
         default:
           location: /
+          proxy_hide_headers: []
           html_file_location: /usr/share/nginx/html
           html_file_name: index.html
           autoindex: false
@@ -224,6 +226,7 @@ nginx_http_template:
       locations:
         backend:
           location: /
+          proxy_hide_headers: []
           proxy_connect_timeout: null
           proxy_pass: http://backend
           #proxy_pass_request_body: off

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -73,6 +73,11 @@ server {
     listen {{ item.value.port }};
 {% endif %}
     server_name {{ item.value.server_name | default('localhost') }};
+{% if item.value.proxy_hide_headers is defined %}
+{% for header in item.value.proxy_hide_headers %}
+    proxy_hide_header {{ header }};
+{% endfor %}
+{% endif %}
 {% if item.value.auth_basic is defined and item.value.auth_basic %}
     auth_basic "{{ item.value.auth_basic }}";
 {% endif %}
@@ -100,6 +105,11 @@ server {
     location {{ item.value.reverse_proxy.locations[location].location }} {
 {% if item.value.reverse_proxy.locations[location].internal is sameas true %}
         internal;
+{% endif %}
+{% if item.value.reverse_proxy.locations[location].proxy_hide_headers is defined %}
+{% for header in item.value.reverse_proxy.locations[location].proxy_hide_headers %}
+        proxy_hide_header {{ header }};
+{% endfor %}
 {% endif %}
 {% if item.value.reverse_proxy.locations[location].auth_request is defined %}
         auth_request {{ item.value.reverse_proxy.locations[location].auth_request }};
@@ -221,6 +231,11 @@ server {
 {% endif %}
 {% if item.value.web_server.locations[location].try_files is defined %}
         try_files {{ item.value.web_server.locations[location].try_files }};
+{% endif %}
+{% if item.value.web_server.locations[location].proxy_hide_headers is defined %}
+{% for header in item.value.web_server.locations[location].proxy_hide_headers %}
+        proxy_hide_header {{ header }};
+{% endfor %}
 {% endif %}
 {% if item.value.web_server.locations[location].returns is defined %}
 {% for code in item.value.web_server.locations[location].returns %}

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -15,6 +15,8 @@
         port: 80
         server_name: localhost
         error_page: /usr/share/nginx/html
+        proxy_hide_headers:
+          - X-Powered-By
         reverse_proxy:
           proxy_cache_path:
             - path: /var/cache/nginx/proxy/frontend
@@ -46,6 +48,8 @@
           locations:
             frontend:
               location: /
+              proxy_hide_headers:
+                - X-Powered-By
               proxy_pass: http://frontend_servers/
               proxy_cache: frontend_proxy_cache
               proxy_temp_path:
@@ -137,6 +141,8 @@
           locations:
             frontend_site:
               location: /
+              proxy_hide_headers:
+                - X-Powered-By
               html_file_location: /usr/share/nginx/html
               html_file_name: frontend_index.html
               autoindex: false


### PR DESCRIPTION
By default, nginx does not pass the header fields “Date”, “Server”, “X-Pad”, and “X-Accel-...” from the response of a proxied server to a client. The proxy_hide_header directive sets additional fields that will not be passed. If, on the contrary, the passing of fields needs to be permitted, the proxy_pass_header directive can be used.

Usage:
```
proxy_hide_headers:
  - X-Powered-By
  - X-You-Shall-Not-Pass
  - [...]
```