### PR TITLE
Add IPv6 listener support; Make listen options configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,10 +356,10 @@ nginx_http_template:
     conf_file_name: default.conf
     conf_file_location: /etc/nginx/conf.d/
     listen:
-      port: 8081
-      opts: [] # Listen opts like http2 which will be added (ssl is automatically added if you specify 'ssl:').
-      ipv4: true
-      ipv6: false
+      listen_localhost:
+        ip: localhost
+        port: 8081
+        opts: [] # Listen opts like http2 which will be added (ssl is automatically added if you specify 'ssl:').
     server_name: localhost
     error_page: /usr/share/nginx/html
     root: /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -355,7 +355,11 @@ nginx_http_template:
     template_file: http/default.conf.j2
     conf_file_name: default.conf
     conf_file_location: /etc/nginx/conf.d/
-    port: 8081
+    listen:
+      port: 8081
+      opts: [] # Listen opts like http2 which will be added (ssl is automatically added if you specify 'ssl:').
+      ipv4: true
+      ipv6: false
     server_name: localhost
     error_page: /usr/share/nginx/html
     root: /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ nginx_http_template:
     conf_file_location: /etc/nginx/conf.d/
     listen:
       listen_localhost:
-        ip: localhost
+        ip: localhost # Wrap in square brackets for IPv6 addresses
         port: 8081
         opts: [] # Listen opts like http2 which will be added (ssl is automatically added if you specify 'ssl:').
     server_name: localhost

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -167,7 +167,11 @@ nginx_http_template:
     template_file: http/default.conf.j2
     conf_file_name: default.conf
     conf_file_location: /etc/nginx/conf.d/
-    port: 8081
+    listen:
+      port: 8081
+      opts: []
+      ipv4: true
+      ipv6: false
     server_name: localhost
     error_page: /usr/share/nginx/html
     root: /usr/share/nginx/html

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -172,7 +172,7 @@ nginx_http_template:
     conf_file_location: /etc/nginx/conf.d/
     listen:
       listen_localhost:
-        ip: localhost
+        ip: localhost # Wrap in square brackets for IPv6 addresses
         port: 8081
         opts: [] # Listen opts like http2 which will be added (ssl is automatically added if you specify 'ssl:').
     server_name: localhost

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -168,10 +168,10 @@ nginx_http_template:
     conf_file_name: default.conf
     conf_file_location: /etc/nginx/conf.d/
     listen:
-      port: 8081
-      opts: [] # Listen opts like http2 which will be added (ssl is automatically added if you specify 'ssl:').
-      ipv4: true
-      ipv6: false
+      listen_localhost:
+        ip: localhost
+        port: 8081
+        opts: [] # Listen opts like http2 which will be added (ssl is automatically added if you specify 'ssl:').
     server_name: localhost
     error_page: /usr/share/nginx/html
     root: /usr/share/nginx/html

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -169,7 +169,7 @@ nginx_http_template:
     conf_file_location: /etc/nginx/conf.d/
     listen:
       port: 8081
-      opts: []
+      opts: [] # Listen opts like http2 which will be added (ssl is automatically added if you specify 'ssl:').
       ipv4: true
       ipv6: false
     server_name: localhost

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -51,7 +51,12 @@ auth_request {{ item.value.auth_request_http }};
 
 server {
 {% if item.value.ssl is defined and item.value.ssl %}
-    listen {{ item.value.port }} ssl;
+{% if ( item.value.listen.ipv4 is defined and item.value.listen.ipv4 ) or ( item.value.listen.ipv4 is not defined ) %}
+    listen {{ item.value.listen.port }} ssl{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
+{% endif %}
+{% if item.value.listen.ipv6 is defined and item.value.listen.ipv6 %}
+    listen [::]:{{ item.value.listen.port }} ipv6only=on ssl{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
+{% endif %}
     ssl_certificate {{ item.value.ssl.cert }};
     ssl_certificate_key {{ item.value.ssl.key }};
 {% if item.value.ssl.dhparam is defined %}
@@ -70,7 +75,12 @@ server {
     ssl_session_timeout {{ item.value.ssl.session_timeout }};
 {% endif %}
 {% else %}
-    listen {{ item.value.port }};
+{% if ( item.value.listen.ipv4 is defined and item.value.listen.ipv4 ) or ( item.value.listen.ipv4 is not defined ) %}
+    listen {{ item.value.listen.port }}{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
+{% endif %}
+{% if item.value.listen.ipv6 is defined and item.value.listen.ipv6 %}
+    listen [::]:{{ item.value.listen.port }} ipv6only=on{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
+{% endif %}
 {% endif %}
     server_name {{ item.value.server_name | default('localhost') }};
 {% if item.value.auth_basic is defined and item.value.auth_basic %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -54,7 +54,7 @@ auth_request_set {{ item.value.auth_request_set_http.name }} {{ item.value.auth_
 
 server {
 {% for listen in item.value.listen %}
-    listen {{ item.value.listen[listen].ip }}:{{ item.value.listen[listen].port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen[listen].opts is defined and item.value.listen[listen].opts | length %} {{ item.value.listen[listen].opts | join(" ") }}{% endif %};
+    listen {% item.value.listen[listen].ip is defined and item.value.listen[listen].ip | length %}{{ item.value.listen[listen].ip }}:{% endif %}{{ item.value.listen[listen].port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen[listen].opts is defined and item.value.listen[listen].opts | length %} {{ item.value.listen[listen].opts | join(" ") }}{% endif %};
 {% endfor %}
     server_name {{ item.value.server_name | default('localhost') }};
 {% if item.value.ssl is defined and item.value.ssl %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -54,7 +54,7 @@ auth_request_set {{ item.value.auth_request_set_http.name }} {{ item.value.auth_
 
 server {
 {% for listen in item.value.listen %}
-    listen {{ listen.ip }}:{{ listen.port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if listen.opts is defined and listen.opts | length %} {{ listen.opts|join(" ") }}{% endif %};
+    listen {{ item.value.listen[listen].ip }}:{{ item.value.listen[listen].port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen[listen].opts is defined and item.value.listen[listen].opts | length %} {{ item.value.listen[listen].opts | join(" ") }}{% endif %};
 {% endfor %}
     server_name {{ item.value.server_name | default('localhost') }};
 {% if item.value.ssl is defined and item.value.ssl %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -54,7 +54,7 @@ auth_request_set {{ item.value.auth_request_set_http.name }} {{ item.value.auth_
 
 server {
 {% for listen in item.value.listen %}
-    listen {% item.value.listen[listen].ip is defined and item.value.listen[listen].ip | length %}{{ item.value.listen[listen].ip }}:{% endif %}{{ item.value.listen[listen].port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen[listen].opts is defined and item.value.listen[listen].opts | length %} {{ item.value.listen[listen].opts | join(" ") }}{% endif %};
+    listen {% if item.value.listen[listen].ip is defined and item.value.listen[listen].ip | length %}{{ item.value.listen[listen].ip }}:{% endif %}{{ item.value.listen[listen].port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen[listen].opts is defined and item.value.listen[listen].opts | length %} {{ item.value.listen[listen].opts | join(" ") }}{% endif %};
 {% endfor %}
     server_name {{ item.value.server_name | default('localhost') }};
 {% if item.value.ssl is defined and item.value.ssl %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -90,6 +90,7 @@ server {
 {% if item.value.ssl.stapling_verify is defined and item.value.ssl.stapling_verify %}
     ssl_stapling_verify on;
 {% endif %}
+{% endif %}
 {% if item.value.include_files is defined and item.value.include_files | length %}
 {% for file in item.value.include_files %}
     include "{{ file }}";

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -54,7 +54,7 @@ server {
     listen {{ item.value.listen.port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
 {% endif %}
 {% if item.value.listen.ipv6 is defined and item.value.listen.ipv6 %}
-    listen [::]:{{ item.value.listen.port }} ipv6only=on{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
+    listen [::]:{{ item.value.listen.port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
 {% endif %}
 {% if item.value.ssl is defined and item.value.ssl %}
     ssl_certificate {{ item.value.ssl.cert }};

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -50,13 +50,13 @@ auth_request {{ item.value.auth_request_http }};
 {% endif %}
 
 server {
-{% if item.value.ssl is defined and item.value.ssl %}
 {% if ( item.value.listen.ipv4 is defined and item.value.listen.ipv4 ) or ( item.value.listen.ipv4 is not defined ) %}
-    listen {{ item.value.listen.port }} ssl{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
+    listen {{ item.value.listen.port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
 {% endif %}
 {% if item.value.listen.ipv6 is defined and item.value.listen.ipv6 %}
-    listen [::]:{{ item.value.listen.port }} ipv6only=on ssl{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
+    listen [::]:{{ item.value.listen.port }} ipv6only=on{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
 {% endif %}
+{% if item.value.ssl is defined and item.value.ssl %}
     ssl_certificate {{ item.value.ssl.cert }};
     ssl_certificate_key {{ item.value.ssl.key }};
 {% if item.value.ssl.dhparam is defined %}
@@ -73,13 +73,6 @@ server {
 {% endif %}
 {% if item.value.ssl.session_timeout is defined and item.value.ssl.session_timeout %}
     ssl_session_timeout {{ item.value.ssl.session_timeout }};
-{% endif %}
-{% else %}
-{% if ( item.value.listen.ipv4 is defined and item.value.listen.ipv4 ) or ( item.value.listen.ipv4 is not defined ) %}
-    listen {{ item.value.listen.port }}{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
-{% endif %}
-{% if item.value.listen.ipv6 is defined and item.value.listen.ipv6 %}
-    listen [::]:{{ item.value.listen.port }} ipv6only=on{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
 {% endif %}
 {% endif %}
     server_name {{ item.value.server_name | default('localhost') }};

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -50,12 +50,9 @@ auth_request {{ item.value.auth_request_http }};
 {% endif %}
 
 server {
-{% if ( item.value.listen.ipv4 is defined and item.value.listen.ipv4 ) or ( item.value.listen.ipv4 is not defined ) %}
-    listen {{ item.value.listen.port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
-{% endif %}
-{% if item.value.listen.ipv6 is defined and item.value.listen.ipv6 %}
-    listen [::]:{{ item.value.listen.port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if item.value.listen.opts is defined and item.value.listen.opts|length %} {{ item.value.listen.opts|join(" ") }}{% endif %};
-{% endif %}
+{% for listen in item.value.listen %}
+    listen {{ listen.ip }}:{{ listen.port }}{% if item.value.ssl is defined and item.value.ssl %} ssl{% endif %}{% if listen.opts is defined and listen.opts | length %} {{ listen.opts|join(" ") }}{% endif %};
+{% endfor %}
 {% if item.value.ssl is defined and item.value.ssl %}
     ssl_certificate {{ item.value.ssl.cert }};
     ssl_certificate_key {{ item.value.ssl.key }};

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -14,7 +14,7 @@
         conf_file_location: /etc/nginx/conf.d/
         listen:
           listen_localhost:
-            ip: localhost
+            ip: 0.0.0.0
             port: 80
             opts:
               - default_server
@@ -136,7 +136,7 @@
             sticky_cookie: false
             servers:
               frontend_server_1:
-                address: localhost
+                address: 0.0.0.0
                 port: 8081
                 weight: 1
                 health_check: max_fails=3 fail_timeout=5s
@@ -148,7 +148,7 @@
             sticky_cookie: false
             servers:
               backend_server_1:
-                address: localhost
+                address: 0.0.0.0
                 port: 8082
                 weight: 1
                 health_check: max_fails=3 fail_timeout=5s
@@ -163,7 +163,6 @@
         conf_file_location: /etc/nginx/conf.d/
         listen:
           listen_localhost:
-            ip: localhost
             port: 8081
             opts: []
         server_name: localhost
@@ -185,7 +184,6 @@
         conf_file_location: /etc/nginx/conf.d/
         listen:
           listen_localhost:
-            ip: localhost
             port: 8082
             opts: []
         server_name: localhost

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -13,11 +13,11 @@
         conf_file_name: default.conf
         conf_file_location: /etc/nginx/conf.d/
         listen:
-          port: 80
-          opts:
-            - default_server
-          ipv4: true
-          ipv6: true
+          listen_localhost:
+            ip: localhost
+            port: 80
+            opts:
+              - default_server
         server_name: localhost
         error_page: /usr/share/nginx/html
         reverse_proxy:
@@ -135,10 +135,10 @@
         conf_file_name: frontend_default.conf
         conf_file_location: /etc/nginx/conf.d/
         listen:
-          port: 8081
-          opts: []
-          ipv4: false
-          ipv6: true
+          listen_localhost:
+            ip: localhost
+            port: 8081
+            opts: []
         server_name: localhost
         error_page: /usr/share/nginx/html
         autoindex: false
@@ -155,10 +155,10 @@
         conf_file_name: backend_default.conf
         conf_file_location: /etc/nginx/conf.d/
         listen:
-          port: 8082
-          opts: []
-          ipv4: true
-          ipv6: false
+          listen_localhost:
+            ip: localhost
+            port: 8082
+            opts: []
         server_name: localhost
         error_page: /usr/share/nginx/html
         autoindex: false

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -12,7 +12,12 @@
         template_file: http/default.conf.j2
         conf_file_name: default.conf
         conf_file_location: /etc/nginx/conf.d/
-        port: 80
+        listen:
+          port: 80
+          opts:
+            - default_server
+          ipv4: true
+          ipv6: true
         server_name: localhost
         error_page: /usr/share/nginx/html
         reverse_proxy:
@@ -129,7 +134,11 @@
         template_file: http/default.conf.j2
         conf_file_name: frontend_default.conf
         conf_file_location: /etc/nginx/conf.d/
-        port: 8081
+        listen:
+          port: 8081
+          opts: []
+          ipv4: false
+          ipv6: true
         server_name: localhost
         error_page: /usr/share/nginx/html
         autoindex: false
@@ -145,7 +154,11 @@
         template_file: http/default.conf.j2
         conf_file_name: backend_default.conf
         conf_file_location: /etc/nginx/conf.d/
-        port: 8082
+        listen:
+          port: 8082
+          opts: []
+          ipv4: true
+          ipv6: false
         server_name: localhost
         error_page: /usr/share/nginx/html
         autoindex: false


### PR DESCRIPTION
This pull request adds the possibility to open an IPv6 socket and make the listen options configurable
(besides 'ssl' for ssl enabled servers and 'ipv6only=on' for IPv6 listeners).

**This change will break the current behavior how ports are defined!**

Old way:  
```
port: 8080
```

New way:  
```
listen:
  port: 8080
  opts: # Listen opts like http2 which will be added (ssl is automatically added if you specify 'ssl:').
    - default_server
  ipv4: true
  ipv6: true
```

Ref:
  - #146 
  - #85 