### PR TITLE
Return

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ nginx_http_template:
             port: 8081
             weight: 1
             health_check: max_fails=1 fail_timeout=10s
-    return:
+    returns:
       return301:
         location: /
         code: 301

--- a/README.md
+++ b/README.md
@@ -493,6 +493,14 @@ nginx_http_template:
             port: 8081
             weight: 1
             health_check: max_fails=1 fail_timeout=10s
+    return:
+      return301:
+        location: /
+        code: 301
+        value: http://$host$request_uri
+      return404:
+        location: /setup
+        code: 404
 
 # Enable NGINX status data.
 # Will enable 'stub_status' in NGINX Open Source and 'status' in NGINX Plus.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -305,6 +305,11 @@ nginx_http_template:
             port: 8081
             weight: 1
             health_check: max_fails=1 fail_timeout=10s
+    return:
+      return301:
+        location: /
+        code: 301
+        value: http://$host$request_uri
 
 # Enable NGINX status data.
 # Will enable 'stub_status' in NGINX Open Source and 'status' in NGINX Plus.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -305,7 +305,7 @@ nginx_http_template:
             port: 8081
             weight: 1
             health_check: max_fails=1 fail_timeout=10s
-    return:
+    returns:
       return301:
         location: /
         code: 301

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -256,10 +256,10 @@ server {
     sub_filter 'proxied_for_ip' '$http_x_forwarded_for';
 {% endif %}
 {% endif %}
-{% if item.value.return is defined %}
-{% for location in item.value.return.locations %}
-    location {{ item.value.return.locations[location].location }} {
-        return {{ item.value.return.locations[location].code }}{% if item.value.return.locations[location].value is defined %} {{ item.value.return.locations[location].value }}{% endif %};
+{% if item.value.returns is defined %}
+{% for return in item.value.returns %}
+    location {{ item.value.returns[return].location }} {
+        return {{ item.value.returns[return].code }}{% if item.value.returns[return].value is defined %} {{ item.value.returns[return].value }}{% endif %};
     }
 {% endfor %}
 {% endif %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -256,6 +256,13 @@ server {
     sub_filter 'proxied_for_ip' '$http_x_forwarded_for';
 {% endif %}
 {% endif %}
+{% if item.value.return is defined %}
+{% for location in item.value.return.locations %}
+    location {{ item.value.return.locations[location].location }} {
+        return {{ item.value.return.locations[location].code }}{% if item.value.return.locations[location].value is defined %} {{ item.value.return.locations[location].value }}{% endif %};
+    }
+{% endfor %}
+{% endif %}
 {% if item.value.error_page is defined %}
     # redirect server error pages to the static page /50x.html
     #

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -125,6 +125,11 @@
                 port: 8082
                 weight: 1
                 health_check: max_fails=3 fail_timeout=5s
+          return:
+            return301:
+              location: ^~ /old-path
+              code: 301
+              value: http://$host/new-path
       frontend:
         template_file: http/default.conf.j2
         conf_file_name: frontend_default.conf

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -125,7 +125,7 @@
                 port: 8082
                 weight: 1
                 health_check: max_fails=3 fail_timeout=5s
-          return:
+          returns:
             return301:
               location: ^~ /old-path
               code: 301

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -125,11 +125,11 @@
                 port: 8082
                 weight: 1
                 health_check: max_fails=3 fail_timeout=5s
-          returns:
-            return301:
-              location: ^~ /old-path
-              code: 301
-              value: http://$host/new-path
+        returns:
+          return301:
+            location: ^~ /old-path
+            code: 301
+            value: http://$host/new-path
       frontend:
         template_file: http/default.conf.j2
         conf_file_name: frontend_default.conf


### PR DESCRIPTION
Add locations with just a return in it.

**Example 1:**  
Config:  
```yaml
nginx_http_template:
  app:
    [...]
    returns:
      return301:
        location: /old-path
        code: 301
        value: http://$host/new/path
```

Output:  
```
location /old-path {
        return 301 http://$host/new/path;
    }
```



**Example 2:**  
Config:  
```yaml
nginx_http_template:
  app:
    [...]
    returns:
      return404:
        location: /setup
        code: 404
```

Output:  
```
location /setup {
        return 404;
    }
```