### PR TITLE
Add proxy_buffering directive to reverse proxy block

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ nginx_http_template:
           proxy_ignore_headers:
             - Vary
             - Cache-Control
+          proxy_buffering: false
           websocket: false
           auth_basic: null
           auth_basic_user_file: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -274,6 +274,7 @@ nginx_http_template:
           proxy_ignore_headers:
             - Vary
             - Cache-Control
+          proxy_buffering: false
           websocket: false
           auth_basic: null
           auth_basic_user_file: null

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -203,6 +203,9 @@ server {
 {% if item.value.reverse_proxy.locations[location].proxy_ignore_headers is defined %}
         proxy_ignore_headers {{ item.value.reverse_proxy.locations[location].proxy_ignore_headers | join(" ") }};
 {% endif %}
+{% if item.value.reverse_proxy.locations[location].proxy_buffering is defined %}
+        proxy_buffering {{ item.value.reverse_proxy.locations[location].proxy_buffering | ternary("on", "off") }};
+{% endif %}
 {% if (item.value.reverse_proxy.health_check_plus is defined) and item.value.reverse_proxy.health_check_plus %}
         health_check;
 {% endif %}

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -73,6 +73,7 @@
                 header_x_forwarded_proto:
                   name: X-Forwarded-Proto
                   value: $scheme
+              proxy_buffering: false
             backend:
               location: /backend
               proxy_pass: http://backend_servers/


### PR DESCRIPTION
Enables or disables buffering of responses from the proxied server.

When buffering is enabled, nginx receives a response from the proxied server as soon as possible, saving it into the buffers set by the proxy_buffer_size and proxy_buffers directives. If the whole response does not fit into memory, a part of it can be saved to a temporary file on the disk. Writing to temporary files is controlled by the proxy_max_temp_file_size and proxy_temp_file_write_size directives.

When buffering is disabled, the response is passed to a client synchronously, immediately as it is received. nginx will not try to read the whole response from the proxied server. The maximum size of the data that nginx can receive from the server at a time is set by the proxy_buffer_size directive. 