### PR TITLE
Proxy cookie path

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,9 @@ nginx_http_template:
           proxy_ignore_headers:
             - Vary
             - Cache-Control
+          proxy_cookie_path:
+            path: /web/
+            replacement: /
           websocket: false
           auth_basic: null
           auth_basic_user_file: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -274,6 +274,9 @@ nginx_http_template:
           proxy_ignore_headers:
             - Vary
             - Cache-Control
+          proxy_cookie_path:
+            path: /web/
+            replacement: /
           websocket: false
           auth_basic: null
           auth_basic_user_file: null

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -203,6 +203,11 @@ server {
 {% if item.value.reverse_proxy.locations[location].proxy_ignore_headers is defined %}
         proxy_ignore_headers {{ item.value.reverse_proxy.locations[location].proxy_ignore_headers | join(" ") }};
 {% endif %}
+
+{% if item.value.reverse_proxy.locations[location].proxy_cookie_path is defined %}
+        proxy_cookie_path {{ item.value.reverse_proxy.locations[location].proxy_cookie_path.path }} {{ item.value.reverse_proxy.locations[location].proxy_cookie_path.replacement }};
+{% endif %}
+
 {% if (item.value.reverse_proxy.health_check_plus is defined) and item.value.reverse_proxy.health_check_plus %}
         health_check;
 {% endif %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -203,11 +203,9 @@ server {
 {% if item.value.reverse_proxy.locations[location].proxy_ignore_headers is defined %}
         proxy_ignore_headers {{ item.value.reverse_proxy.locations[location].proxy_ignore_headers | join(" ") }};
 {% endif %}
-
 {% if item.value.reverse_proxy.locations[location].proxy_cookie_path is defined %}
         proxy_cookie_path {{ item.value.reverse_proxy.locations[location].proxy_cookie_path.path }} {{ item.value.reverse_proxy.locations[location].proxy_cookie_path.replacement }};
 {% endif %}
-
 {% if (item.value.reverse_proxy.health_check_plus is defined) and item.value.reverse_proxy.health_check_plus %}
         health_check;
 {% endif %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -246,6 +246,7 @@ server {
 {% endif %}
 {% if item.value.reverse_proxy.locations[location].proxy_cookie_path is defined %}
         proxy_cookie_path {{ item.value.reverse_proxy.locations[location].proxy_cookie_path.path }} {{ item.value.reverse_proxy.locations[location].proxy_cookie_path.replacement }};
+{% endif %}
 {% if item.value.reverse_proxy.locations[location].proxy_buffering is defined %}
         proxy_buffering {{ item.value.reverse_proxy.locations[location].proxy_buffering | ternary("on", "off") }};
 {% endif %}

--- a/tests/playbooks/nginx-http-template.yml
+++ b/tests/playbooks/nginx-http-template.yml
@@ -100,6 +100,9 @@
                 header_x_forwarded_proto:
                   name: X-Forwarded-Proto
                   value: $scheme
+              proxy_cookie_path:
+                path: /web/
+                replacement: /
         upstreams:
           frontend_upstream:
             name: frontend_servers


### PR DESCRIPTION
 Sets a text that should be changed in the path attribute of the “Set-Cookie” header fields of a proxied server response. Suppose a proxied server returned the “Set-Cookie” header field with the attribute “path=/two/some/uri/”. The directive

> proxy_cookie_path /two/ /;  
will rewrite this attribute to “path=/some/uri/”.

The path and replacement strings can contain variables:  
> proxy_cookie_path $uri /some$uri;

Usage:  
```yaml
proxy_cookie_path:
  path: /web/
  replacement: /
```