### PR TITLE
Support 'client_max_body_size' (server, location)

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ nginx_http_template:
     #auth_request_set:
       #name: $auth_user
       #value: $upstream_http_x_user
+    client_max_body_size: 1m
     add_headers:
       strict_transport_security:
         name: Strict-Transport-Security
@@ -415,6 +416,7 @@ nginx_http_template:
           #auth_request_set:
             #name: $auth_user
             #value: $upstream_http_x_user
+          client_max_body_size: 1m
           #returns:
             #return302:
               #code: 302

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -183,6 +183,7 @@ nginx_http_template:
     #auth_request_set:
       #name: $auth_user
       #value: $upstream_http_x_user
+    client_max_body_size: 1m
     add_headers:
       strict_transport_security:
         name: Strict-Transport-Security
@@ -227,6 +228,7 @@ nginx_http_template:
           #auth_request_set:
             #name: $auth_user
             #value: $upstream_http_x_user
+          client_max_body_size: 1m
           #returns:
             #return302:
               #code: 302

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -117,6 +117,9 @@ server {
 {% if item.value.auth_request_set is defined %}
     auth_request_set {{ item.value.auth_request_set.name }} {{ item.value.auth_request_set.value }};
 {% endif %}
+{% if item.value.client_max_body_size is defined and item.value.client_max_body_size %}
+    client_max_body_size {{ item.value.client_max_body_size }};
+{% endif %}
 
 {% if item.value.reverse_proxy is defined and item.value.reverse_proxy %}
 {% for location in item.value.reverse_proxy.locations %}
@@ -240,6 +243,9 @@ server {
 {% endif %}
 {% if item.value.reverse_proxy.locations[location].proxy_ignore_headers is defined %}
         proxy_ignore_headers {{ item.value.reverse_proxy.locations[location].proxy_ignore_headers | join(" ") }};
+{% endif %}
+{% if item.value.reverse_proxy.locations[location].client_max_body_size is defined and item.value.reverse_proxy.locations[location].client_max_body_size %}
+        client_max_body_size {{ item.value.reverse_proxy.locations[location].client_max_body_size }};
 {% endif %}
 {% if (item.value.reverse_proxy.health_check_plus is defined) and item.value.reverse_proxy.health_check_plus %}
         health_check;


### PR DESCRIPTION
I've implemented support for the 'client_max_body_size' parameter in the templated configuration, both at the `server` and `location` levels (missing as per  #155).
