### PR TITLE
Support for 'include' directive in http templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ nginx_http_template:
     conf_file_location: /etc/nginx/conf.d/
     port: 8081
     server_name: localhost
+    include_files: []
     error_page: /usr/share/nginx/html
     root: /usr/share/nginx/html
     https_redirect: false
@@ -399,6 +400,7 @@ nginx_http_template:
       locations:
         default:
           location: /
+          include_files: []
           proxy_hide_headers: [] # A list of headers which shouldn't be passed to the application
           add_headers:
             strict_transport_security:
@@ -448,6 +450,7 @@ nginx_http_template:
       locations:
         backend:
           location: /
+          include_files: []
           proxy_hide_headers: [] # A list of headers which shouldn't be passed to the application
           add_headers:
             strict_transport_security:

--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ nginx_stream_template:
         listen_address: localhost
         listen_port: 80
         udp_enable: false
+        include_files: []
         proxy_pass: backend
         proxy_timeout: 3s
         proxy_connect_timeout: 1s

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -172,6 +172,7 @@ nginx_http_template:
     conf_file_location: /etc/nginx/conf.d/
     port: 8081
     server_name: localhost
+    include_files: []
     error_page: /usr/share/nginx/html
     root: /usr/share/nginx/html
     https_redirect: false
@@ -211,6 +212,7 @@ nginx_http_template:
       locations:
         default:
           location: /
+          include_files: []
           proxy_hide_headers: [] # A list of headers which shouldn't be passed to the application
           add_headers:
             strict_transport_security:
@@ -260,6 +262,7 @@ nginx_http_template:
       locations:
         backend:
           location: /
+          include_files: []
           proxy_hide_headers: [] # A list of headers which shouldn't be passed to the application
           add_headers:
             strict_transport_security:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -393,6 +393,7 @@ nginx_stream_template:
         listen_address: localhost
         listen_port: 80
         udp_enable: false
+        include_files: []
         proxy_pass: backend
         proxy_timeout: 3s
         proxy_connect_timeout: 1s

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -91,6 +91,11 @@ server {
     listen {{ item.value.port }};
 {% endif %}
     server_name {{ item.value.server_name | default('localhost') }};
+{% if item.value.include_files is defined and item.value.include_files | length %}
+{% for file in item.value.include_files %}
+    include "{{ file }}";
+{% endfor %}
+{% endif %}
 {% if item.value.proxy_hide_headers is defined %}
 {% for header in item.value.proxy_hide_headers %}
     proxy_hide_header {{ header }};
@@ -134,6 +139,11 @@ server {
     location {{ item.value.reverse_proxy.locations[location].location }} {
 {% if item.value.reverse_proxy.locations[location].internal is sameas true %}
         internal;
+{% endif %}
+{% if item.value.reverse_proxy.locations[location].include_files is defined and item.value.reverse_proxy.locations[location].include_files | length %}
+{% for file in item.value.reverse_proxy.locations[location].include_files %}
+        include "{{ file }}";
+{% endfor %}
 {% endif %}
 {% if item.value.reverse_proxy.locations[location].proxy_hide_headers is defined %}
 {% for header in item.value.reverse_proxy.locations[location].proxy_hide_headers %}
@@ -288,6 +298,11 @@ server {
 {% endif %}
 {% if item.value.web_server.locations[location].try_files is defined %}
         try_files {{ item.value.web_server.locations[location].try_files }};
+{% endif %}
+{% if item.value.web_server.locations[location].include_files is defined and item.value.web_server.locations[location].include_files | length %}
+{% for file in item.value.web_server.locations[location].include_files %}
+        include "{{ file }}";
+{% endfor %}
 {% endif %}
 {% if item.value.web_server.locations[location].proxy_hide_headers is defined %}
 {% for header in item.value.web_server.locations[location].proxy_hide_headers %}

--- a/templates/stream/default.conf.j2
+++ b/templates/stream/default.conf.j2
@@ -43,6 +43,11 @@ server {
     listen {{ item.value.network_streams[stream].listen_port }};
 {% endif %}
 {% endif %}
+{% if item.value.network_streams[stream].include_files is defined and item.value.network_streams[stream].include_files | length %}
+{% for file in item.value.network_streams[stream].include_files %}
+    include "{{ file }}";
+{% endfor %}
+{% endif %}
     proxy_pass {{ item.value.network_streams[stream].proxy_pass }};
     proxy_timeout {{ item.value.network_streams[stream].proxy_timeout }};
     proxy_connect_timeout {{ item.value.network_streams[stream].proxy_connect_timeout }};


### PR DESCRIPTION
Our original necessity is the same as #133, but we'd rather implement it through an `include` directive and a whitelist file.
Additionally, it shores up missing support for other directives that might not have yet been implemented.