### PR TITLE
Add setting worker_rlimit_nofile

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ nginx_main_template:
   conf_file_location: /etc/nginx/
   user: nginx
   worker_processes: auto
+  worker_rlimit_nofile: undefined # Used when a number is given
   error_level: warn
   worker_connections: 1024
   http_enable: true

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ nginx_main_template:
   conf_file_location: /etc/nginx/
   user: nginx
   worker_processes: auto
-  worker_rlimit_nofile: undefined # Used when a number is given
+  #worker_rlimit_nofile: 1024
   error_level: warn
   worker_connections: 1024
   http_enable: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -146,6 +146,7 @@ nginx_main_template:
   conf_file_location: /etc/nginx/
   user: nginx
   worker_processes: auto
+  worker_rlimit_nofile: undefined # Used when a number is given
   error_level: warn
   worker_connections: 1024
   http_enable: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -146,7 +146,7 @@ nginx_main_template:
   conf_file_location: /etc/nginx/
   user: nginx
   worker_processes: auto
-  worker_rlimit_nofile: undefined # Used when a number is given
+  #worker_rlimit_nofile: 1024
   error_level: warn
   worker_connections: 1024
   http_enable: true

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -34,7 +34,7 @@ load_module modules/ngx_http_modsecurity_module.so;
 user  {{ nginx_main_template.user }};
 worker_processes  {{ nginx_main_template.worker_processes }};
 
-{% if nginx_main_template.worker_rlimit_nofile is defined and nginx_main_template.worker_rlimit_nofile != "undefined" %}
+{% if nginx_main_template.worker_rlimit_nofile is defined %}
 worker_rlimit_nofile {{ nginx_main_template.worker_rlimit_nofile }};
 {% endif %}
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -34,6 +34,10 @@ load_module modules/ngx_http_modsecurity_module.so;
 user  {{ nginx_main_template.user }};
 worker_processes  {{ nginx_main_template.worker_processes }};
 
+{% if nginx_main_template.worker_rlimit_nofile is defined and nginx_main_template.worker_rlimit_nofile != "undefined" %}
+worker_rlimit_nofile {{ nginx_main_template.worker_rlimit_nofile }};
+{% endif %}
+
 error_log  /var/log/nginx/error.log {{ nginx_main_template.error_level }};
 pid        /var/run/nginx.pid;
 


### PR DESCRIPTION
Since `worker_rlimit_nofile` has no default value ([ref](http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile)), I used the dummy value `undefined` and use the setting only if it's different.