### PR TITLE
Add server_tokens (#173)

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ nginx_main_template:
     cache: false
     rate_limit: false
     keyval: false
+    #server_tokens: "off"
   http_global_autoindex: false
   #http_custom_options: []
   stream_enable: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -166,6 +166,7 @@ nginx_main_template:
     cache: false
     rate_limit: false
     keyval: false
+    #server_tokens: "off"
   http_global_autoindex: false
   #http_custom_options: []
   stream_enable: false

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -73,6 +73,10 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
+{% if nginx_main_template.http_settings.server_tokens is defined %}
+    server_tokens {{ nginx_main_template.http_settings.server_tokens }};
+{% endif %}
+
     keepalive_timeout  {{ nginx_main_template.http_settings.keepalive_timeout }};
 
     #gzip  on;


### PR DESCRIPTION
Add `server_tokens` config option to control [server_tokens](nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens) setting.