### PR TITLE
Added proxy_cache_valid support

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,11 @@ nginx_http_template:
             verify_depth: 1
             session_reuse: true
           proxy_cache: frontend_proxy_cache
+          proxy_cache_valid:
+            - code: 200
+              time: 10m
+            - code: 301
+              time: 1m
           proxy_temp_path:
             path: /var/cache/nginx/proxy/backend/temp
           proxy_cache_lock: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -283,6 +283,11 @@ nginx_http_template:
           use_temp_path: true
       proxy_temp_path:
         path: /var/cache/nginx/proxy/temp
+      proxy_cache_valid:
+        - code: 200
+          time: 10m
+        - code: 301
+          time: 1m
       proxy_cache_lock: true
       proxy_cache_min_uses: 5
       proxy_cache_revalidate: true
@@ -350,7 +355,12 @@ nginx_http_template:
             verify: false
             verify_depth: 1
             session_reuse: true
-          proxy_cache: frontend_proxy_cache
+          proxy_cache: backend_proxy_cache
+          proxy_cache_valid:
+            - code: 200
+              time: 10m
+            - code: 301
+              time: 1m
           proxy_temp_path:
             path: /var/cache/nginx/proxy/backend/temp
           proxy_cache_lock: false

--- a/molecule/template/playbook.yml
+++ b/molecule/template/playbook.yml
@@ -102,6 +102,11 @@
                   always: false
               proxy_pass: http://frontend_servers/
               proxy_cache: frontend_proxy_cache
+              proxy_cache_valid:
+                - code: 200
+                  time: 10m
+                - code: 301
+                  time: 1m
               proxy_temp_path:
                 path: /var/cache/nginx/proxy/frontend/temp
               proxy_cache_lock: false
@@ -133,6 +138,8 @@
               location: /backend
               proxy_pass: http://backend_servers/
               proxy_cache: backend_proxy_cache
+              proxy_cache_valid:
+                - time: 10m
               proxy_temp_path:
                 path: /var/cache/nginx/proxy/backend/temp
               proxy_cache_lock: true

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -283,15 +283,13 @@ server {
         proxy_cache {{ item.value.reverse_proxy.locations[location].proxy_cache }};
 {% endif %}
 {% if item.value.reverse_proxy.locations[location].proxy_cache_valid is defined %}
-{% if item.value.reverse_proxy.locations[location].proxy_cache_valid.code is defined %}
 {% for proxy_cache_valid in item.value.reverse_proxy.locations[location].proxy_cache_valid %}
-        proxy_cache_valid {{ proxy_cache_valid.code }} {{ proxy_cache_valid.time }};
-{% endfor %}
-{% else %}
-{% for proxy_cache_valid in item.value.reverse_proxy.locations[location].proxy_cache_valid %}
+{% if proxy_cache_valid.code is defined %}
+        proxy_cache_valid {{ proxy_cache_valid.code }} {{ proxy_cache_valid.time | default("10m") }};
+{% elif proxy_cache_valid.time is defined and proxy_cache_time.code is not defined %}
         proxy_cache_valid {{ proxy_cache_valid.time }};
-{% endfor %}
 {% endif %}
+{% endfor %}
 {% endif %}
 {% if item.value.reverse_proxy.locations[location].proxy_cache_background_update is defined %}
         proxy_cache_background_update {{ item.value.reverse_proxy.locations[location].proxy_cache_background_update | ternary("on", "off") }};

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -26,8 +26,8 @@ upstream {{ item.value.upstreams[upstream].name }} {
 {% if item.value.reverse_proxy.proxy_cache_path is defined and item.value.reverse_proxy.proxy_cache_path %}
 {% for proxy_cache_path in item.value.reverse_proxy.proxy_cache_path %}
 proxy_cache_path {{ proxy_cache_path.path }} keys_zone={{ proxy_cache_path.keys_zone.name }}:{{ proxy_cache_path.keys_zone.size }}
-                 levels={{ proxy_cache_path.levels }} max_size={{ proxy_cache_path.max_size }}
-                 inactive={{ proxy_cache_path.inactive }} use_temp_path={{ proxy_cache_path.use_temp_path | ternary("on", "off") }};
+                levels={{ proxy_cache_path.levels }} max_size={{ proxy_cache_path.max_size }}
+                inactive={{ proxy_cache_path.inactive }} use_temp_path={{ proxy_cache_path.use_temp_path | ternary("on", "off") }};
 {% endfor %}
 {% if item.value.reverse_proxy.proxy_cache_background_update is defined and item.value.reverse_proxy.proxy_cache_background_update%}
 proxy_cache_background_update {{ item.value.reverse_proxy.proxy_cache_background_update | ternary("on", "off") }};
@@ -49,6 +49,15 @@ proxy_ignore_headers {{ item.value.reverse_proxy.proxy_ignore_headers | join(" "
 {% endif %}
 {% if item.value.reverse_proxy.proxy_temp_path is defined and item.value.reverse_proxy.proxy_temp_path.path %}
 proxy_temp_path {{ item.value.reverse_proxy.proxy_temp_path.path }} {{ item.value.reverse_proxy.proxy_temp_path.level_1 | default("") }} {{ item.value.reverse_proxy.proxy_temp_path.level_2 | default("") }} {{ item.value.reverse_proxy.proxy_temp_path.level_3 | default("") }};
+{% endif %}
+{% if item.value.reverse_proxy.locations[location].proxy_cache_valid is defined %}
+{% for proxy_cache_valid in item.value.reverse_proxy.locations[location].proxy_cache_valid %}
+{% if proxy_cache_valid.code is defined %}
+proxy_cache_valid {{ proxy_cache_valid.code }} {{ proxy_cache_valid.time | default("10m") }};
+{% elif proxy_cache_valid.time is defined and proxy_cache_time.code is not defined %}
+proxy_cache_valid {{ proxy_cache_valid.time }};
+{% endif %}
+{% endfor %}
 {% endif %}
 {% endif %}
 {% endif %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -50,11 +50,11 @@ proxy_ignore_headers {{ item.value.reverse_proxy.proxy_ignore_headers | join(" "
 {% if item.value.reverse_proxy.proxy_temp_path is defined and item.value.reverse_proxy.proxy_temp_path.path %}
 proxy_temp_path {{ item.value.reverse_proxy.proxy_temp_path.path }} {{ item.value.reverse_proxy.proxy_temp_path.level_1 | default("") }} {{ item.value.reverse_proxy.proxy_temp_path.level_2 | default("") }} {{ item.value.reverse_proxy.proxy_temp_path.level_3 | default("") }};
 {% endif %}
-{% if item.value.reverse_proxy.locations[location].proxy_cache_valid is defined %}
-{% for proxy_cache_valid in item.value.reverse_proxy.locations[location].proxy_cache_valid %}
+{% if item.value.reverse_proxy.proxy_cache_valid is defined %}
+{% for proxy_cache_valid in item.value.reverse_proxy.proxy_cache_valid %}
 {% if proxy_cache_valid.code is defined %}
 proxy_cache_valid {{ proxy_cache_valid.code }} {{ proxy_cache_valid.time | default("10m") }};
-{% elif proxy_cache_valid.time is defined and proxy_cache_time.code is not defined %}
+{% elif proxy_cache_valid.time is defined and proxy_cache_valid.code is not defined %}
 proxy_cache_valid {{ proxy_cache_valid.time }};
 {% endif %}
 {% endfor %}
@@ -295,7 +295,7 @@ server {
 {% for proxy_cache_valid in item.value.reverse_proxy.locations[location].proxy_cache_valid %}
 {% if proxy_cache_valid.code is defined %}
         proxy_cache_valid {{ proxy_cache_valid.code }} {{ proxy_cache_valid.time | default("10m") }};
-{% elif proxy_cache_valid.time is defined and proxy_cache_time.code is not defined %}
+{% elif proxy_cache_valid.time is defined and proxy_cache_valid.code is not defined %}
         proxy_cache_valid {{ proxy_cache_valid.time }};
 {% endif %}
 {% endfor %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -282,6 +282,17 @@ server {
 {% if item.value.reverse_proxy.locations[location].proxy_cache is defined %}
         proxy_cache {{ item.value.reverse_proxy.locations[location].proxy_cache }};
 {% endif %}
+{% if item.value.reverse_proxy.locations[location].proxy_cache_valid is defined %}
+{% if item.value.reverse_proxy.locations[location].proxy_cache_valid.code is defined %}
+{% for proxy_cache_valid in item.value.reverse_proxy.locations[location].proxy_cache_valid %}
+        proxy_cache_valid {{ proxy_cache_valid.code }} {{ proxy_cache_valid.time }};
+{% endfor %}
+{% else %}
+{% for proxy_cache_valid in item.value.reverse_proxy.locations[location].proxy_cache_valid %}
+        proxy_cache_valid {{ proxy_cache_valid.time }};
+{% endfor %}
+{% endif %}
+{% endif %}
 {% if item.value.reverse_proxy.locations[location].proxy_cache_background_update is defined %}
         proxy_cache_background_update {{ item.value.reverse_proxy.locations[location].proxy_cache_background_update | ternary("on", "off") }};
 {% endif %}


### PR DESCRIPTION
I noticed that the default template did not have support for `proxy_cache_valid`. In this PR, I have:

- Updated the default template so it accepts and renders proxy_valid_cache

- Updated the README

- Updated the molecule playbook and run the molecule test suite to ensure it passes.

Please let me know if you have any questions.