### PR TITLE
Fixed bug on tcp_nopush and tcp_nodelay for nginx.conf.j2

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -72,10 +72,10 @@ http {
 
     sendfile        on;
 
-{% if nginx_main_template.http_settings.tcp_nopush is defined and nginx_main_template.tcp_nopush %}
+{% if nginx_main_template.http_settings.tcp_nopush is defined and nginx_main_template.http_settings.tcp_nopush %}
     tcp_nopush      on;
 {% endif %}
-{% if nginx_main_template.http_settings.tcp_nodelay is defined and nginx_main_template.tcp_nodelay %}
+{% if nginx_main_template.http_settings.tcp_nodelay is defined and nginx_main_template.http_settings.tcp_nodelay %}
     tcp_nodelay     on;
 {% endif %}
 


### PR DESCRIPTION
There were a bug for `tcp_nopush` and `tcp_nodelay` that were getting from `nginx_main_template`