### PR TITLE
Don't enforce the use of lb_method in upstream.

### DIFF
--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -3,7 +3,7 @@
 {% if item.value.upstreams is defined and item.value.upstreams %}
 {% for upstream in item.value.upstreams %}
 upstream {{ item.value.upstreams[upstream].name }} {
-{% if item.value.upstreams[upstream].lb_method is defined %}
+{% if item.value.upstreams[upstream].lb_method is defined and item.value.upstreams[upstream].lb_method | length %}
     {{ item.value.upstreams[upstream].lb_method }};
 {% endif %}
 {% if item.value.upstreams[upstream].zone_name is defined and item.value.upstreams[upstream].zone_name %}

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -3,7 +3,9 @@
 {% if item.value.upstreams is defined and item.value.upstreams %}
 {% for upstream in item.value.upstreams %}
 upstream {{ item.value.upstreams[upstream].name }} {
+{% if item.value.upstreams[upstream].lb_method is defined %}
     {{ item.value.upstreams[upstream].lb_method }};
+{% endif %}
 {% if item.value.upstreams[upstream].zone_name is defined and item.value.upstreams[upstream].zone_name %}
     zone {{ item.value.upstreams[upstream].zone_name }} {{ item.value.upstreams[upstream].zone_size }};
 {% endif %}


### PR DESCRIPTION
The default load balancing method in Nginx is `round-robin`, this is achieved by not defining `lb_method`.

In this case, if people want `least-connected` or `ip-hash`, they can define `lb_method` and it will work as before.