### PR TITLE
    Configure min_ansible_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,12 @@ This role installs NGINX Open Source, NGINX Plus, the NGINX Amplify agent, the N
 Requirements
 ------------
 
-This role was developed using Ansible 2.4.0.0. Backwards compatibility is not guaranteed.
+**Ansible**
+
+This role was developed and tested with [maintained](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#release-status) versions of
+Ansible. Backwards compatibility is not guaranteed.
+
+**Ansible Galaxy**
 
 Use `ansible-galaxy install nginxinc.nginx` to install the role on your system.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
 
   license: Apache License, Version 2.0
 
-  min_ansible_version: 2.4.0.0
+  min_ansible_version: 2.7
 
   platforms:
     - name: Alpine


### PR DESCRIPTION
    * Meta min_ansible_version: 2.7; last maintained version
    * README updated; Role developed with maintained versions

Proposed Ansible update plan (As discussed in #193 )
- it should at least be updated to the least supported version at the moment
- it'd be good to follow the official Ansible version support guidelines
https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html
- make sure the role works with the latest three Ansible releases
