### PR TITLE
Delete NGINX Plus repository when license is deleted

### DIFF
--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -19,10 +19,11 @@ nginx_type: opensource
 # Default is empty.
 # nginx_version: =19-1~bionic
 
-# Specify whether you want to maintain your version of NGINX or upgrade to the latest version.
+# Specify whether you want to maintain your version of NGINX, upgrade to the latest version, or remove NGINX.
 # Can be used with `nginx_version` to achieve fine tune control on which version of NGINX is installed/used on each playbook execution.
 # Using 'present' will install the latest version (or 'nginx_version') of NGINX on a fresh install.
 # Using 'latest' will upgrade NGINX to the latest version (that matches your 'nginx_version') of NGINX on every playbook execution.
+# Using 'absent' will remove NGINX from your system.
 # Default is present.
 nginx_state: present
 
@@ -53,7 +54,7 @@ nginx_license:
   certificate: license/nginx-repo.crt
   key: license/nginx-repo.key
 
-# Delete NGINX Plus license after installation for security purposes.
+# Remove NGINX Plus license and repository after installation for security purposes.
 # Default is false.
 nginx_delete_license: false
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,9 @@
       tags: nginx_debug_output
 
     - import_tasks: plus/delete-license.yml
-      when: nginx_type == "plus" and nginx_delete_license
+      when:
+        - nginx_type == "plus"
+        - nginx_delete_license
       tags: nginx_delete_license
 
   when: nginx_enable | bool

--- a/tasks/plus/delete-license.yml
+++ b/tasks/plus/delete-license.yml
@@ -1,5 +1,34 @@
 ---
-- name: "(All OSs) Delete NGINX Plus License"
+- name: "(Setup: All OSs) Set NGINX Plus License State"
+  set_fact:
+    nginx_license_status: absent
+
+- name: "(Setup: All OSs Besides Alpine Linux) Delete NGINX Plus License"
   file:
     path: /etc/ssl/nginx
     state: absent
+  when: ansible_distribution != "Alpine"
+
+- name: "(Setup: Alpine Linux) Delete NGINX Plus License"
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/apk/cert.key
+    - /etc/apk/cert.pem
+  when: ansible_distribution == "Alpine"
+
+- import_tasks: setup-alpine.yml
+  when: ansible_os_family == "Alpine"
+
+- import_tasks: setup-bsd.yml
+  when: ansible_os_family == "FreeBSD"
+
+- import_tasks: setup-debian.yml
+  when: ansible_os_family == "Debian"
+
+- import_tasks: setup-redhat.yml
+  when: ansible_os_family == "RedHat"
+
+- import_tasks: setup-suse.yml
+  when: ansible_os_family == "Suse"

--- a/tasks/plus/install-plus-bsd.yml
+++ b/tasks/plus/install-plus-bsd.yml
@@ -1,30 +1,9 @@
 ---
-- name: "(Install: FreeBSD)"
-  block:
+- import_tasks: setup-bsd.yml
+  when: ansible_os_family == "FreeBSD"
 
-    - name: "(Install: FreeBSD) Add NGINX Plus Repository"
-      blockinfile:
-        path: /etc/pkg/nginx-plus.conf
-        create: yes
-        block: |
-          nginx-plus: {
-          URL: pkg+https://plus-pkgs.nginx.com/freebsd/${ABI}/latest
-          ENABLED: yes
-          MIRROR_TYPE: SRV
-          }
-
-    - name: "(Install: FreeBSD) Verify NGINX Plus License"
-      blockinfile:
-        path: /usr/local/etc/pkg.conf
-        block: |
-          PKG_ENV: { SSL_NO_VERIFY_PEER: "1",
-          SSL_CLIENT_CERT_FILE: "/etc/ssl/nginx/nginx-repo.crt",
-          SSL_CLIENT_KEY_FILE: "/etc/ssl/nginx/nginx-repo.key" }
-
-    - name: "(Install: FreeBSD) Install nginx-plus{{ nginx_version | default('') }}"
-      pkgng:
-        name: "nginx-plus{{ nginx_version | default('') }}"
-        state: "{{ nginx_state }}"
-      notify: "(Handler: All OSs) Start NGINX"
-
-  when: ansible_system == "FreeBSD"
+- name: "(Install: FreeBSD) Install NGINX Plus"
+  pkgng:
+    name: "nginx-plus{{ nginx_version | default('') }}"
+    state: "{{ nginx_state }}"
+  notify: "(Handler: All OSs) Start NGINX"

--- a/tasks/plus/install-plus-linux.yml
+++ b/tasks/plus/install-plus-linux.yml
@@ -1,4 +1,7 @@
 ---
+- import_tasks: setup-alpine.yml
+  when: ansible_os_family == "Alpine"
+
 - import_tasks: setup-debian.yml
   when: ansible_os_family == "Debian"
 
@@ -7,9 +10,6 @@
 
 - import_tasks: setup-suse.yml
   when: ansible_os_family == "Suse"
-
-- import_tasks: setup-alpine.yml
-  when: ansible_os_family == "Alpine"
 
 - name: "(Install: Linux) Install NGINX Plus"
   package:

--- a/tasks/plus/setup-alpine.yml
+++ b/tasks/plus/setup-alpine.yml
@@ -1,6 +1,7 @@
 ---
-- name: "(Install: Alpine Linux) Add NGINX Plus Repository"
+- name: "(Setup: Alpine Linux) Setup NGINX Plus Repository"
   lineinfile:
     path: /etc/apk/repositories
     insertafter: EOF
     line: "https://plus-pkgs.nginx.com/alpine/v{{ ansible_distribution_version | regex_search('^[0-9]+\\.[0-9]+') }}/main"
+    state: "{{ nginx_license_status | default ('present') }}"

--- a/tasks/plus/setup-bsd.yml
+++ b/tasks/plus/setup-bsd.yml
@@ -1,0 +1,21 @@
+---
+- name: "(Setup: FreeBSD) Setup NGINX Plus Repository"
+  blockinfile:
+    path: /etc/pkg/nginx-plus.conf
+    create: yes
+    block: |
+      nginx-plus: {
+      URL: pkg+https://plus-pkgs.nginx.com/freebsd/${ABI}/latest
+      ENABLED: yes
+      MIRROR_TYPE: SRV
+      }
+    state: "{{ nginx_license_status | default ('present') }}"
+
+- name: "(Setup: FreeBSD) Setup NGINX Plus License"
+  blockinfile:
+    path: /usr/local/etc/pkg.conf
+    block: |
+      PKG_ENV: { SSL_NO_VERIFY_PEER: "1",
+      SSL_CLIENT_CERT_FILE: "/etc/ssl/nginx/nginx-repo.crt",
+      SSL_CLIENT_KEY_FILE: "/etc/ssl/nginx/nginx-repo.key" }
+    state: "{{ nginx_license_status | default ('present') }}"

--- a/tasks/plus/setup-debian.yml
+++ b/tasks/plus/setup-debian.yml
@@ -1,11 +1,12 @@
 ---
-- name: "(Install: Debian/Ubuntu) Add NGINX Plus Repository"
+- name: "(Setup: Debian/Ubuntu) Setup NGINX Plus Repository"
   apt_repository:
     repo: deb https://plus-pkgs.nginx.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} nginx-plus
     filename: nginx-plus
     update_cache: no
+    state: "{{ nginx_license_status | default ('present') }}"
 
-- name: "(Install: Debian/Ubuntu) Verify NGINX Plus License"
+- name: "(Setup: Debian/Ubuntu) Setup NGINX Plus License"
   blockinfile:
     path: /etc/apt/apt.conf.d/90nginx
     create: yes
@@ -14,7 +15,8 @@
       Acquire::https::plus-pkgs.nginx.com::Verify-Host "true";
       Acquire::https::plus-pkgs.nginx.com::SslCert     "/etc/ssl/nginx/nginx-repo.crt";
       Acquire::https::plus-pkgs.nginx.com::SslKey      "/etc/ssl/nginx/nginx-repo.key";
+    state: "{{ nginx_license_status | default ('present') }}"
 
-- name: "(Install: Debian/Ubuntu) Update APT Cache"
+- name: "(Setup: Debian/Ubuntu) Update APT Cache"
   apt:
     update_cache: yes

--- a/tasks/plus/setup-license.yml
+++ b/tasks/plus/setup-license.yml
@@ -1,13 +1,13 @@
 ---
-- name: "(All OSs) Setup NGINX Plus License"
+- name: "(Setup: All OSs Besides Alpine Linux) Setup NGINX Plus License"
   block:
 
-    - name: "(All OSs) Create SSL Directory"
+    - name: "(Setup: All OSs Besides Alpine Linux) Create SSL Directory"
       file:
         path: /etc/ssl/nginx
         state: directory
 
-    - name: "(All OSs) Copy NGINX Plus Certificate and License Key"
+    - name: "(Setup: All OSs Besides Alpine Linux) Copy NGINX Plus Certificate and License Key"
       copy:
         src: "{{ item }}"
         dest: /etc/ssl/nginx
@@ -18,21 +18,21 @@
 
   when: ansible_distribution != "Alpine"
 
-- name: "(Alpine Linux) Setup NGINX Plus License"
+- name: "(Setup: Alpine Linux) Setup NGINX Plus License"
   block:
 
-    - name: "(Alpine Linux) Create APK Directory"
+    - name: "(Setup: Alpine Linux) Create APK Directory"
       file:
         path: /etc/apk
         state: directory
 
-    - name: "(Alpine Linux) Copy NGINX Plus Key"
+    - name: "(Setup: Alpine Linux) Copy NGINX Plus Key"
       copy:
         src: "{{ nginx_license.key }}"
         dest: /etc/apk/cert.key
         decrypt: yes
 
-    - name: "(Alpine Linux) Copy NGINX Plus Certificate"
+    - name: "(Setup: Alpine Linux) Copy NGINX Plus Certificate"
       copy:
         src: "{{ nginx_license.certificate }}"
         dest: /etc/apk/cert.pem

--- a/tasks/plus/setup-redhat.yml
+++ b/tasks/plus/setup-redhat.yml
@@ -1,5 +1,5 @@
 ---
-- name: "(Install: CentOS/RedHat/Oracle Linux) Add NGINX Plus Repository"
+- name: "(Setup: CentOS/RedHat/Oracle Linux) Setup NGINX Plus Repository"
   yum_repository:
     name: nginx-plus
     baseurl: >-
@@ -10,9 +10,10 @@
     sslclientkey: /etc/ssl/nginx/nginx-repo.key
     enabled: yes
     gpgcheck: yes
+    state: "{{ nginx_license_status | default ('present') }}"
   when: ansible_distribution != "Amazon"
 
-- name: "(Install: Amazon Linux) Add NGINX Plus Repository"
+- name: "(Setup: Amazon Linux) Setup NGINX Plus Repository"
   yum_repository:
     name: nginx-plus
     baseurl: >-
@@ -23,4 +24,5 @@
     sslclientkey: /etc/ssl/nginx/nginx-repo.key
     enabled: yes
     gpgcheck: yes
+    state: "{{ nginx_license_status | default ('present') }}"
   when: ansible_distribution == "Amazon"

--- a/tasks/plus/setup-suse.yml
+++ b/tasks/plus/setup-suse.yml
@@ -1,10 +1,11 @@
 ---
-- name: "(Install: SUSE) Combine NGINX Plus Certificate and License Keys"
+- name: "(Setup: SUSE) Setup NGINX Plus Certificate and License Keys"
   assemble:
     src: /etc/ssl/nginx
     dest: /etc/ssl/nginx/nginx-repo-bundle.crt
 
-- name: "(Install: SUSE) Add NGINX Plus Repository"
+- name: "(Setup: SUSE) Setup NGINX Plus Repository"
   zypper_repository:
     name: nginx-plus
     repo: "https://plus-pkgs.nginx.com/sles/{{ ansible_distribution_major_version }}?ssl_clientcert=/etc/ssl/nginx/nginx-repo-bundle.crt&ssl_verify=host"
+    state: "{{ nginx_license_status | default ('present') }}"


### PR DESCRIPTION
This fixes a bug when only the license is deleted, making system updates fail since the NGINX Plus repository is still within the repositories list yet there is no license to authenticate to the repository