### PR TITLE
Make ssl optional for listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ This is a sample playbook file for deploying the Ansible Galaxy NGINX role in a 
               listen_localhost:
                 ip: 0.0.0.0
                 port: 8081
+                ssl: false
                 opts: []
             server_name: localhost
             error_page: /usr/share/nginx/html
@@ -371,6 +372,7 @@ This is a sample playbook file for deploying the Ansible Galaxy NGINX role in a 
               listen_localhost:
                 ip: 0.0.0.0
                 port: 8082
+                ssl: false
                 opts: []
             server_name: localhost
             error_page: /usr/share/nginx/html

--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -64,6 +64,7 @@ nginx_http_template:
           listen_localhost:
             ip: localhost  # Wrap in square brackets for IPv6 addresses
             port: 8081
+            ssl: true
             opts: []  # Listen opts like http2 which will be added (ssl is automatically added if you specify 'ssl:').
         server_name: localhost
         include_files: []

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -80,7 +80,7 @@ auth_request_set {{ item.value.auth_request_set_http.name }} {{ item.value.auth_
 {% for server in item.value.servers %}
 server {
 {% for listen in item.value.servers[server].listen %}
-    listen {% if item.value.servers[server].listen[listen].ip is defined and item.value.servers[server].listen[listen].ip | length %}{{ item.value.servers[server].listen[listen].ip }}:{% endif %}{{ item.value.servers[server].listen[listen].port }}{% if item.value.servers[server].ssl is defined and item.value.servers[server].ssl %} ssl{% endif %}{% if item.value.servers[server].listen[listen].opts is defined and item.value.servers[server].listen[listen].opts | length %} {{ item.value.servers[server].listen[listen].opts | join(" ") }}{% endif %};
+    listen {% if item.value.servers[server].listen[listen].ip is defined and item.value.servers[server].listen[listen].ip | length %}{{ item.value.servers[server].listen[listen].ip }}:{% endif %}{{ item.value.servers[server].listen[listen].port }}{% if item.value.servers[server].listen[listen].ssl is defined and item.value.servers[server].listen[listen].ssl %} ssl{% endif %}{% if item.value.servers[server].listen[listen].opts is defined and item.value.servers[server].listen[listen].opts | length %} {{ item.value.servers[server].listen[listen].opts | join(" ") }}{% endif %};
 {% endfor %}
     server_name {{ item.value.servers[server].server_name | default('localhost') }};
 {% if item.value.servers[server].ssl is defined and item.value.servers[server].ssl %}


### PR DESCRIPTION
### Proposed changes
Make ssl optional for listeners to not force ssl on ports like 80
### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/master/CONTRIBUTING.md) document
-   [ ] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all unit tests pass after adding my changes
-   [x] If required, I have updated necessary documentation (`defaults/main/` and `README.md`)
