### PR TITLE
Update minimum Ansible version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 before_install:
   - sudo apt-get -qq update
 install:
-  - pip install ansible==2.9.2
+  - pip install ansible==2.9.4
   - pip install molecule[docker]==2.22
 script:
   - travis_wait 50 molecule test -s $scenario

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
 
   license: Apache License, Version 2.0
 
-  min_ansible_version: 2.7
+  min_ansible_version: 2.9
 
   platforms:
     - name: Alpine


### PR DESCRIPTION
### Proposed changes
An issue was introduced in 2.8.8 and 2.9.3 that breaks the `disablerepo` parameter in the `yum` module. Ansible 2.9.4 fixes this issue, but for the time being the fix has not been back ported to 2.8. Ansible 2.7 should still work, but I'm making the decision to set 2.9 as the minimum version given the circumstances.

Resolves #219 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/master/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all unit tests pass after adding my changes
-   [x] If required, I have updated necessary documentation (`defaults/main/` and `README.md`)
