### PR TITLE
Add ssl_ecdh_curve and ssl_buffer_size directives

### DIFF
--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -114,6 +114,8 @@ nginx_http_template:
           trusted_cert: /etc/ssl/certs/root_CA_cert_plus_intermediates.crt
           stapling: true
           stapling_verify: true
+          buffer_size: 16k
+          ecdh_curve: auto
         sub_filter:
           # sub_filters: []
           last_modified: "off"

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -116,6 +116,12 @@ server {
 {% if item.value.servers[server].ssl.stapling_verify is defined and item.value.servers[server].ssl.stapling_verify %}
     ssl_stapling_verify on;
 {% endif %}
+{% if item.value.servers[server].ssl.ecdh_curve is defined and item.value.servers[server].ssl.ecdh_curve %}
+    ssl_ecdh_curve {{ item.value.servers[server].ssl.ecdh_curve }};
+{% endif %}
+{% if item.value.servers[server].ssl.buffer_size is defined and item.value.servers[server].ssl.buffer_size %}
+    ssl_buffer_size {{ item.value.servers[server].ssl.buffer_size }};
+{% endif %}
 {% endif %}
 {% if item.value.servers[server].include_files is defined and item.value.servers[server].include_files | length %}
 {% for file in item.value.servers[server].include_files %}


### PR DESCRIPTION
Added only the possibility to edit ssl_buffer_size, ssl_ecdh_curve when using default.conf template.