### PR TITLE
Allow proxy_http_version and websocket whithout proxy_set_header

### DIFF
--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -265,13 +265,13 @@ server {
 {% for header in item.value.servers[server].reverse_proxy.locations[location].proxy_set_header %}
         proxy_set_header {{ item.value.servers[server].reverse_proxy.locations[location].proxy_set_header[header].name }} {{ item.value.servers[server].reverse_proxy.locations[location].proxy_set_header[header].value }};
 {% endfor %}
+{% endif %}
 {% if item.value.servers[server].reverse_proxy.locations[location].proxy_http_version is defined %}
         proxy_http_version {{ item.value.servers[server].reverse_proxy.locations[location].proxy_http_version }};
 {% endif %}
 {% if item.value.servers[server].reverse_proxy.locations[location].websocket is defined and item.value.servers[server].reverse_proxy.locations[location].websocket %}
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
-{% endif %}
 {% endif %}
 {% if item.value.servers[server].reverse_proxy.locations[location].try_files is defined %}
         try_files {{ item.value.servers[server].reverse_proxy.locations[location].try_files }};


### PR DESCRIPTION
Hello, thank you for the great work.

For reverse proxy the two variable :
- websocket
- proxy_http_version

Are not handle by the default http template if the variable:
- proxy_set_header

is not set

So to make them work if you don't have any other header to set, you have to declare an empty **proxy_set_header** variable, which is not so beautiful (I think)

```yaml
            reverse_proxy:
              locations:
                frontend:
                  location: /
                  proxy_pass: "{{ local_url }}"
                  proxy_set_header: [] # needed to enable the two next
                  proxy_http_version: 1.1
                  websocket: true
```

So this patch try to fix this to allow:

```yaml
            reverse_proxy:
              locations:
                frontend:
                  location: /
                  proxy_pass: "{{ local_url }}"
                  proxy_http_version: 1.1
                  websocket: true
```