### PR TITLE
Remove semicolons from custom_options

### DIFF
--- a/molecule/common/playbook_template.yml
+++ b/molecule/common/playbook_template.yml
@@ -298,11 +298,11 @@
                   html_file_location: /usr/share/nginx/html
                   autoindex: false
                   custom_options:
-                    - fastcgi_split_path_info ^(.+\.php)(/.+)$
-                    - fastcgi_pass unix:/run/php/php7.2-fpm.sock
-                    - fastcgi_index index.php
-                    - include fastcgi_params
-                    - fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name
+                    - fastcgi_split_path_info ^(.+\.php)(/.+)$;
+                    - fastcgi_pass unix:/run/php/php7.2-fpm.sock;
+                    - fastcgi_index index.php;
+                    - include fastcgi_params;
+                    - fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
               sub_filter:
                 # sub_filters: []
                 last_modified: "off"

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -17,7 +17,7 @@ upstream {{ item.value.upstreams[upstream].name }} {
 {% endif %}
 {% if item.value.upstreams[upstream].custom_options is defined and item.value.upstreams[upstream].custom_options | length %}
 {% for inline_option in item.value.upstreams[upstream].custom_options %}
-    {{ inline_option }};
+    {{ inline_option }}
 {% endfor %}
 {% endif %}
 }
@@ -72,7 +72,7 @@ auth_request_set {{ item.value.auth_request_set_http.name }} {{ item.value.auth_
 
 {% if item.value.custom_options is defined and item.value.custom_options | length %}
 {% for inline_option in item.value.custom_options %}
-{{ inline_option }};
+{{ inline_option }}
 {% endfor %}
 {% endif %}
 
@@ -181,7 +181,7 @@ server {
 {% endif %}
 {% if item.value.servers[server].custom_options is defined and item.value.servers[server].custom_options | length %}
 {% for inline_option in item.value.servers[server].custom_options %}
-    {{ inline_option }};
+    {{ inline_option }}
 {% endfor %}
 {% endif %}
 
@@ -370,7 +370,7 @@ server {
 {% endif %}
 {% if item.value.servers[server].reverse_proxy.locations[location].custom_options is defined and item.value.servers[server].reverse_proxy.locations[location].custom_options | length %}
 {% for inline_option in item.value.servers[server].reverse_proxy.locations[location].custom_options %}
-        {{ inline_option }};
+        {{ inline_option }}
 {% endfor %}
 {% endif %}
 {% if (item.value.servers[server].reverse_proxy.health_check_plus is defined) and item.value.servers[server].reverse_proxy.health_check_plus %}
@@ -403,7 +403,7 @@ server {
 {% endif %}
 {% if item.value.servers[server].web_server.locations[location].custom_options is defined and item.value.servers[server].web_server.locations[location].custom_options | length %}
 {% for inline_option in item.value.servers[server].web_server.locations[location].custom_options %}
-        {{ inline_option }};
+        {{ inline_option }}
 {% endfor %}
 {% endif %}
 {% if item.value.servers[server].web_server.locations[location].proxy_hide_headers is defined %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -40,7 +40,7 @@ worker_rlimit_nofile {{ nginx_main_template.worker_rlimit_nofile }};
 
 {% if nginx_main_template.custom_options is defined and nginx_main_template.custom_options | length %}
 {% for inline_option in nginx_main_template.custom_options %}
-{{ inline_option }};
+{{ inline_option }}
 {% endfor %}
 {% endif %}
 
@@ -52,7 +52,7 @@ events {
     worker_connections  {{ nginx_main_template.worker_connections }};
 {% if nginx_main_template.events_custom_options is defined and nginx_main_template.events_custom_options | length %}
 {% for inline_option in nginx_main_template.events_custom_options %}
-    {{ inline_option }};
+    {{ inline_option }}
 {% endfor %}
 {% endif %}
 }
@@ -115,7 +115,7 @@ http {
 {% endif %}
 {% if nginx_main_template.http_custom_options is defined and nginx_main_template.http_custom_options | length %}
 {% for inline_option in nginx_main_template.http_custom_options %}
-    {{ inline_option }};
+    {{ inline_option }}
 {% endfor %}
 {% endif %}
     include /etc/nginx/conf.d/*.conf;
@@ -126,7 +126,7 @@ http {
 stream {
 {% if nginx_main_template.stream_custom_options is defined and nginx_main_template.stream_custom_options | length %}
 {% for inline_option in nginx_main_template.stream_custom_options %}
-    {{ inline_option }};
+    {{ inline_option }}
 {% endfor %}
 {% endif %}
     include /etc/nginx/conf.d/stream/*.conf;

--- a/templates/stream/default.conf.j2
+++ b/templates/stream/default.conf.j2
@@ -17,7 +17,7 @@ upstream {{ item.value.upstreams[upstream].name }} {
 {% endif %}
 {% if item.value.upstreams[upstream].custom_options is defined and item.value.upstreams[upstream].custom_options | length %}
 {% for inline_option in item.value.upstreams[upstream].custom_options %}
-    {{ inline_option }};
+    {{ inline_option }}
 {% endfor %}
 {% endif %}
 }
@@ -26,7 +26,7 @@ upstream {{ item.value.upstreams[upstream].name }} {
 
 {% if item.value.custom_options is defined and item.value.custom_options | length %}
 {% for inline_option in item.value.custom_options %}
-{{ inline_option }};
+{{ inline_option }}
 {% endfor %}
 {% endif %}
 
@@ -105,7 +105,7 @@ server {
 {% endif %}
 {% if item.value.network_streams[stream].custom_options is defined and item.value.network_streams[stream].custom_options | length %}
 {% for inline_option in item.value.network_streams[stream].custom_options %}
-    {{ inline_option }};
+    {{ inline_option }}
 {% endfor %}
 {% endif %}
 }


### PR DESCRIPTION
### Proposed changes
This will fix #226 -- custom blocks such as `if` blocks are not working as intended unless a comment sign is added at the end of each line

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/master/CONTRIBUTING.md) document
-   [x] If necessary, I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all unit tests pass after adding my changes
-   [x] If required, I have updated necessary documentation (`defaults/main/` and `README.md`)
