### PR TITLE
Systemd

### DIFF
--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -94,3 +94,9 @@ nginx_cleanup_config_path:
   - directory:
       - /etc/nginx/conf.d
     recurse: false
+
+# Set service timeout for systemd systems in seconds (default is 90s)
+# nginx_service_timeout: 120
+
+# Set the restart policy for systemd systems in seconds (default is not to set this)
+# nginx_service_restartonfailure: 30

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -95,8 +95,9 @@ nginx_cleanup_config_path:
       - /etc/nginx/conf.d
     recurse: false
 
-# Set service timeout for systemd systems in seconds (default is 90s)
-# nginx_service_timeout: 120
-
-# Set the restart policy for systemd systems in seconds (default is not to set this)
-# nginx_service_restartonfailure: 30
+# Enable systemd modifications
+nginx_service_modify: false
+# Set service timeout for systemd systems in seconds (default is 90s) - no effect unless nginx_service_modify is true
+nginx_service_timeout: 120
+# Set the restart policy for systemd systems in seconds (default is not to set this) - no effect unless nginx_service_modify is true
+nginx_service_restartonfailure: 30

--- a/molecule/common/playbook_default.yml
+++ b/molecule/common/playbook_default.yml
@@ -17,7 +17,7 @@
     - name: "Enable Nginx @CentOS-AppStream dnf modules"
       shell:
       args:
-        cmd: dnf module info nginx | grep -q 'Stream.*\[e\]' && echo -n ENABLED || dnf module enable -y nginx # noqa 204 303
+        cmd: dnf module info nginx | grep -q 'Stream.*\[e\]' && echo -n ENABLED || dnf module enable -y nginx  # noqa 204 303
       register: dnf_module_enable
       changed_when: dnf_module_enable.stdout != 'ENABLED'
       when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"

--- a/molecule/common/playbook_template.yml
+++ b/molecule/common/playbook_template.yml
@@ -221,6 +221,10 @@
                 port: 8082
                 weight: 1
                 health_check: max_fails=3 fail_timeout=5s
+              backend_server_2:
+                address: unix:/var/run/control.unit.sock
+                weight: 1
+                health_check: max_fails=3 fail_timeout=5s
       frontend:
         template_file: http/default.conf.j2
         conf_file_name: frontend_default.conf

--- a/molecule/common/playbook_template.yml
+++ b/molecule/common/playbook_template.yml
@@ -6,6 +6,9 @@
   vars:
     nginx_debug_output: true
 
+    nginx_service_modify: true
+    nginx_service_timeout: 95
+
     nginx_main_template_enable: true
     nginx_main_template:
       template_file: nginx.conf.j2

--- a/tasks/opensource/install-oss-linux.yml
+++ b/tasks/opensource/install-oss-linux.yml
@@ -16,6 +16,9 @@
 
   when: nginx_install_from == "nginx_repository"
 
+- import_tasks: setup-systemd.yml
+  when: ansible_service_mgr == "systemd"
+
 - name: "(Install: Linux) Install NGINX from source"
   import_tasks: setup-source.yml
   when: nginx_install_from == "source"

--- a/tasks/opensource/setup-systemd.yml
+++ b/tasks/opensource/setup-systemd.yml
@@ -4,7 +4,7 @@
     path: /etc/systemd/system/nginx.service.d
     state: directory
     mode: '0755'
-  when: nginx_service_timeout or nginx_service_restartonfailure is defined
+  when: nginx_service_modify
 
 - name: "(Install: Linux) Increase timeout for NGINX Plus Service"
   template:
@@ -13,4 +13,4 @@
     owner: root
     group: root
     mode: '0644'
-  when: nginx_service_timeout or nginx_service_restartonfailure is defined
+  when: nginx_service_modify

--- a/tasks/opensource/setup-systemd.yml
+++ b/tasks/opensource/setup-systemd.yml
@@ -1,0 +1,16 @@
+---
+- name: "(Install: Linux) Create override for NGINX Plus service"
+  file:
+    path: /etc/systemd/system/nginx.service.d
+    state: directory
+    mode: '0755'
+  when: nginx_service_timeout or nginx_service_restartonfailure is defined
+
+- name: "(Install: Linux) Increase timeout for NGINX Plus Service"
+  template:
+    src: nginx.service.override.conf.j2
+    dest: /etc/systemd/system/nginx.service.d/override.conf
+    owner: root
+    group: root
+    mode: '0644'
+  when: nginx_service_timeout or nginx_service_restartonfailure is defined

--- a/tasks/opensource/setup-systemd.yml
+++ b/tasks/opensource/setup-systemd.yml
@@ -8,7 +8,7 @@
 
 - name: "(Install: Linux) Increase timeout for NGINX Plus Service"
   template:
-    src: nginx.service.override.conf.j2
+    src: services/nginx.service.override.conf.j2
     dest: /etc/systemd/system/nginx.service.d/override.conf
     owner: root
     group: root

--- a/tasks/plus/install-plus-linux.yml
+++ b/tasks/plus/install-plus-linux.yml
@@ -11,6 +11,9 @@
 - import_tasks: setup-suse.yml
   when: ansible_os_family == "Suse"
 
+- import_tasks: setup-systemd.yml
+  when: ansible_service_mgr == "systemd"
+
 - name: "(Install: Linux) Install NGINX Plus"
   package:
     name: "nginx-plus{{ nginx_version | default('') }}"

--- a/tasks/plus/setup-systemd.yml
+++ b/tasks/plus/setup-systemd.yml
@@ -1,0 +1,16 @@
+---
+- name: "(Install: Linux) Create override for NGINX Plus service"
+  file:
+    path: /etc/systemd/system/nginx.service.d
+    state: directory
+    mode: '0755'
+  when: nginx_service_timeout or nginx_service_restartonfailure is defined
+
+- name: "(Install: Linux) Increase timeout for NGINX Plus Service"
+  template:
+    src: nginx.service.override.conf.j2
+    dest: /etc/systemd/system/nginx.service.d/override.conf
+    owner: root
+    group: root
+    mode: '0644'
+  when: nginx_service_timeout or nginx_service_restartonfailure is defined

--- a/tasks/plus/setup-systemd.yml
+++ b/tasks/plus/setup-systemd.yml
@@ -8,7 +8,7 @@
 
 - name: "(Install: Linux) Increase timeout for NGINX Plus Service"
   template:
-    src: nginx.service.override.conf.j2
+    src: services/nginx.service.override.conf.j2
     dest: /etc/systemd/system/nginx.service.d/override.conf
     owner: root
     group: root

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -10,7 +10,7 @@ upstream {{ item.value.upstreams[upstream].name }} {
     zone {{ item.value.upstreams[upstream].zone_name }} {{ item.value.upstreams[upstream].zone_size }};
 {% endif %}
 {% for server in item.value.upstreams[upstream].servers %}
-    server {{ item.value.upstreams[upstream].servers[server].address }}:{{ item.value.upstreams[upstream].servers[server].port }} weight={{ item.value.upstreams[upstream].servers[server].weight|default("1") }} {{ item.value.upstreams[upstream].servers[server].health_check|default("") }};
+    server {{ item.value.upstreams[upstream].servers[server].address }}{{(":" + item.value.upstreams[upstream].servers[server].port | string) if item.value.upstreams[upstream].servers[server].port is defined}} weight={{ item.value.upstreams[upstream].servers[server].weight | default("1") }} {{ item.value.upstreams[upstream].servers[server].health_check | default("") }};
 {% endfor %}
 {% if item.value.upstreams[upstream].sticky_cookie %}
     sticky cookie srv_id expires=1h  path=/;

--- a/templates/services/nginx.service.override.conf.j2
+++ b/templates/services/nginx.service.override.conf.j2
@@ -1,0 +1,9 @@
+[Service]
+{% if nginx_service_timeout is defined %}
+TimeoutStopSec={{ nginx_service_timeout }}
+{% endif %}
+{% if nginx_service_restartonfailure is defined %}
+Restart=on-failure
+RestartSec={{ nginx_service_restartonfailure }}
+{% endif %}
+


### PR DESCRIPTION
### Proposed changes
Adds [restart=on-failure](https://github.com/nginxinc/ansible-role-nginx/issues/244) and a timeout for systemd systems 
Uses the proper /etc/systemd/system/nginx.service.d/overrides.conf format (this is the correct form).
Allows future use cases
Added variables at bottom of main.yml
filters for systemd through ansible facts (similar to OSS Source install)
Applies to OSS and Plus NGINX installs.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/master/CONTRIBUTING.md) document
-   [X] If necessary, I have added Molecule tests that prove my fix is effective or that my feature works
-   [X] I have checked that all unit tests pass after adding my changes
-   [X] If required, I have updated necessary documentation (`defaults/main/` and `README.md`)
