### PR TITLE
Adding nginx_main_template.http_custom_includes

### DIFF
--- a/defaults/main/template.yml
+++ b/defaults/main/template.yml
@@ -48,6 +48,7 @@ nginx_main_template:
     types: "text/html"
   # custom_options: []
   # http_custom_options: []
+  # http_custom_includes: []
   # events_custom_options: []
   stream_enable: false
   # stream_custom_options: []

--- a/molecule/common/playbook_template.yml
+++ b/molecule/common/playbook_template.yml
@@ -43,6 +43,8 @@
         - master_process on;
       http_custom_options:
         - aio off;
+      http_custom_includes:
+        - "/etc/nginx/sites-enabled/*.conf"
       events_custom_options:
         - accept_mutex off;
       stream_enable: true

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -119,6 +119,11 @@ http {
 {% endfor %}
 {% endif %}
     include /etc/nginx/conf.d/*.conf;
+{% if nginx_main_template.http_custom_includes is defined and nginx_main_template.http_custom_includes | length %}
+{% for inline_include in nginx_main_template.http_custom_includes %}
+    include {{ inline_option }};
+{% endfor %}
+{% endif %}
 }
 {% endif %}
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -121,7 +121,7 @@ http {
     include /etc/nginx/conf.d/*.conf;
 {% if nginx_main_template.http_custom_includes is defined and nginx_main_template.http_custom_includes | length %}
 {% for inline_include in nginx_main_template.http_custom_includes %}
-    include {{ inline_option }};
+    include {{ inline_include }};
 {% endfor %}
 {% endif %}
 }


### PR DESCRIPTION
### Proposed changes
This PR addresses issue #180 : A new variable key `nginx_main_template.http_custom_includes` is added. The intended behavior described in #180 can be achieved by setting:
```
nginx_main_template:
  http_custom_includes:
  - "/etc/nginx/sites-enabled/*.conf"
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/master/CONTRIBUTING.md) document
-   [x] If necessary, I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all unit tests pass after adding my changes
-   [x] If required, I have updated necessary documentation (`defaults/main/` and `README.md`)
