### PR TITLE
Fix error when http_demo_conf undefined

### DIFF
--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -454,7 +454,7 @@ server {
 
     }
 {% endfor %}
-{% if item.value.servers[server].web_server.http_demo_conf %}
+{% if item.value.servers[server].web_server.http_demo_conf is defined %}
     sub_filter_once off;
     sub_filter 'server_hostname' '$hostname';
     sub_filter 'server_address' '$server_addr:$server_port';

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -454,7 +454,7 @@ server {
 
     }
 {% endfor %}
-{% if item.value.servers[server].web_server.http_demo_conf is defined %}
+{% if item.value.servers[server].web_server.http_demo_conf is defined and item.value.servers[server].web_server.http_demo_conf %}
     sub_filter_once off;
     sub_filter 'server_hostname' '$hostname';
     sub_filter 'server_address' '$server_addr:$server_port';


### PR DESCRIPTION
### Proposed changes
When using the default http template with `web_server`, if `http_demo_conf` is not defined the template interpolation fails.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [X] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/master/CONTRIBUTING.md) document
-   [x] If necessary, I have added Molecule tests that prove my fix is effective or that my feature works
-   [X] I have checked that all unit tests pass after adding my changes
-   [x] If required, I have updated necessary documentation (`defaults/main/` and `README.md`)
