### PR TITLE
Add support for down parameter for upstreams

### DIFF
--- a/molecule/common/playbook_template.yml
+++ b/molecule/common/playbook_template.yml
@@ -242,6 +242,10 @@
                 address: unix:/var/run/control.unit.sock
                 weight: 1
                 health_check: max_fails=3 fail_timeout=5s
+              backend_server_3:
+                address: 0.0.0.0
+                port: 8083
+                down: true
       frontend:
         template_file: http/default.conf.j2
         conf_file_name: frontend_default.conf
@@ -378,3 +382,7 @@
                 port: 8091
                 weight: 1
                 health_check: max_fails=1 fail_timeout=10s
+              backend_server_2:
+                address: 0.0.0.0
+                port: 8092
+                down: true

--- a/templates/http/default.conf.j2
+++ b/templates/http/default.conf.j2
@@ -10,7 +10,7 @@ upstream {{ item.value.upstreams[upstream].name }} {
     zone {{ item.value.upstreams[upstream].zone_name }} {{ item.value.upstreams[upstream].zone_size }};
 {% endif %}
 {% for server in item.value.upstreams[upstream].servers %}
-    server {{ item.value.upstreams[upstream].servers[server].address }}{{(":" + item.value.upstreams[upstream].servers[server].port | string) if item.value.upstreams[upstream].servers[server].port is defined}} weight={{ item.value.upstreams[upstream].servers[server].weight | default("1") }} {{ item.value.upstreams[upstream].servers[server].health_check | default("") }};
+    server {{ item.value.upstreams[upstream].servers[server].address }}{{(":" + item.value.upstreams[upstream].servers[server].port | string) if item.value.upstreams[upstream].servers[server].port is defined}} {% if item.value.upstreams[upstream].servers[server].down is defined and item.value.upstreams[upstream].servers[server].down %}down{% else %}weight={{ item.value.upstreams[upstream].servers[server].weight | default("1") }} {{ item.value.upstreams[upstream].servers[server].health_check | default("") }}{% endif %};
 {% endfor %}
 {% if item.value.upstreams[upstream].sticky_cookie %}
     sticky cookie srv_id expires=1h  path=/;

--- a/templates/stream/default.conf.j2
+++ b/templates/stream/default.conf.j2
@@ -8,7 +8,7 @@ upstream {{ item.value.upstreams[upstream].name }} {
 {% endif %}
     zone {{ item.value.upstreams[upstream].zone_name }} {{ item.value.upstreams[upstream].zone_size }};
 {% for server in item.value.upstreams[upstream].servers %}
-    server {{ item.value.upstreams[upstream].servers[server].address }}:{{ item.value.upstreams[upstream].servers[server].port }} weight={{ item.value.upstreams[upstream].servers[server].weight|default("1") }} {{ item.value.upstreams[upstream].servers[server].health_check|default("") }};
+    server {{ item.value.upstreams[upstream].servers[server].address }}{{(":" + item.value.upstreams[upstream].servers[server].port | string) if item.value.upstreams[upstream].servers[server].port is defined}} {% if item.value.upstreams[upstream].servers[server].down is defined and item.value.upstreams[upstream].servers[server].down %}down{% else %}weight={{ item.value.upstreams[upstream].servers[server].weight | default("1") }} {{ item.value.upstreams[upstream].servers[server].health_check | default("") }}{% endif %};
 {% endfor %}
 {% if item.value.upstreams[upstream].sticky_cookie is defined %}
 {% if item.value.upstreams[upstream].sticky_cookie %}


### PR DESCRIPTION
### Proposed changes
Add support for the `down` parameter to allow permanently marking upstream servers as unavailable.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/master/CONTRIBUTING.md) document

-   [x] If necessary, I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all unit tests pass after adding my changes
-   [x] If required, I have updated necessary documentation (`defaults/main/` and `README.md`)
