### PR TITLE
Flush handlers before running `nginx -T` and setting up logrotate

### DIFF
--- a/tasks/conf/logrotate.yml
+++ b/tasks/conf/logrotate.yml
@@ -33,9 +33,6 @@
     dest: "/etc/logrotate.d/nginx"
   register: nginx_logrotate_result
 
-- name: "(Config: All OSs) Ensure NGINX is Running"
-  meta: flush_handlers
-
 - name: "(Config: All OSs) Run Logrotate"
   command: logrotate -f /etc/logrotate.d/nginx
   changed_when: nginx_logrotate_result.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,15 +53,22 @@
       when: true in nginx_modules.values()
       tags: nginx_install_modules
 
-    - include_tasks: "{{ role_path }}/tasks/conf/debug-output.yml"
-      when: nginx_debug_output | bool
-      tags: nginx_debug_output
-
     - include_tasks: "{{ role_path }}/tasks/plus/delete-license.yml"
       when:
         - nginx_type == "plus"
         - nginx_delete_license
       tags: nginx_delete_license
+
+    - name: "(Config: All OSs) Ensure NGINX is Running"
+      meta: flush_handlers
+
+    - include_tasks: "{{ role_path }}/tasks/conf/debug-output.yml"
+      when: nginx_debug_output | bool
+      tags: nginx_debug_output
+
+    - include_tasks: "{{ role_path }}/tasks/conf/logrotate.yml"
+      when: nginx_logrotate_conf_enable | bool
+      tags: nginx_logrotate_config
 
   when: nginx_enable | bool
 
@@ -75,7 +82,3 @@
 - include_tasks: "{{ role_path }}/tasks/unit/install-unit.yml"
   when: nginx_unit_enable | bool
   tags: nginx_install_unit
-
-- include_tasks: "{{ role_path }}/tasks/conf/logrotate.yml"
-  when: nginx_logrotate_conf_enable | bool
-  tags: nginx_logrotate_config


### PR DESCRIPTION
### Proposed changes
Flush handlers before running `nginx -T` and setting up logrotate. This should fix `nginx_debug_output` not working correctly on some systems where the `nginx` service isn't started upon installing `nginx`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/master/CONTRIBUTING.md) document
-   [x] If necessary, I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all unit tests pass after adding my changes
-   [x] If required, I have updated necessary documentation (`defaults/main/` and `README.md`)
