### PR TITLE
Remove root HTML tasks from source install

### DIFF
--- a/molecule/common/playbook_source.yml
+++ b/molecule/common/playbook_source.yml
@@ -12,8 +12,3 @@
     nginx_install_source_pcre: false
     nginx_install_source_openssl: true
     nginx_install_source_zlib: false
-
-    nginx_main_upload_enable: true
-    nginx_main_upload_src: files/nginx.conf
-    nginx_http_upload_enable: true
-    nginx_http_upload_src: files/http/*.conf

--- a/tasks/opensource/setup-source.yml
+++ b/tasks/opensource/setup-source.yml
@@ -343,19 +343,6 @@
         chdir: "/tmp/{{ nginx_version }}"
         target: install
 
-    - name: "(Install: Linux) Install NGINX: Create html directory"
-      file:
-        path: /usr/share/nginx/html
-        state: directory
-
-    - name: "(Install: Linux) Install NGINX: Copy index.html"
-      copy:
-        src: www/index.html
-        owner: root
-        group: root
-        mode: '0644'
-        dest: /usr/share/nginx/html/index.html
-
     - name: "(Install: Linux) Upload systemd NGINX service file"
       copy:
         src: services/nginx.systemd


### PR DESCRIPTION
### Proposed changes
NGINX automatically creates a root HTML site when installing from source

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/master/CONTRIBUTING.md) document
-   [x] If necessary, I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all unit tests pass after adding my changes
-   [x] If required, I have updated necessary documentation (`defaults/main/` and `README.md`)
