### PR TITLE
Remove arch descriptor from Debian/Ubuntu src repo

### DIFF
--- a/tasks/opensource/setup-debian.yml
+++ b/tasks/opensource/setup-debian.yml
@@ -6,7 +6,7 @@
         deb [arch=amd64] https://nginx.org/packages/{{ (nginx_branch == 'mainline')
         | ternary('mainline/', '') }}{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} nginx
       - >-
-        deb-src [arch=amd64] https://nginx.org/packages/{{ (nginx_branch == 'mainline')
+        deb-src https://nginx.org/packages/{{ (nginx_branch == 'mainline')
         | ternary('mainline/', '') }}{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} nginx
 
 - name: "(Install: Debian/Ubuntu) Set APT NGINX Repository"

--- a/tasks/unit/setup-debian.yml
+++ b/tasks/unit/setup-debian.yml
@@ -4,4 +4,4 @@
     repo: "{{ item }}"
   with_items:
     - deb [arch=amd64] https://packages.nginx.org/unit/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} unit
-    - deb-src [arch=amd64] https://packages.nginx.org/unit/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} unit
+    - deb-src https://packages.nginx.org/unit/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} unit


### PR DESCRIPTION

### Proposed changes
Remove the arch descriptor from the Debian/Ubuntu `deb-src` repos. Resolves #245.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/master/CONTRIBUTING.md) document
-   [x] If necessary, I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all unit tests pass after adding my changes
-   [x] If required, I have updated necessary documentation (`defaults/main/` and `README.md`)
