### PR TITLE
Typo in Allow Rest API ports

### DIFF
--- a/tasks/prerequisites/setup-selinux.yml
+++ b/tasks/prerequisites/setup-selinux.yml
@@ -56,7 +56,7 @@
     proto: tcp
     setype: http_port_t
     state: present
-  when: nginx_rest_api_port is defined"
+  when: nginx_rest_api_port is defined
 
 - name: "(Setup: SELinux: Ports) Allow Specific TCP Ports"
   seport:


### PR DESCRIPTION
### Proposed changes
Typo in Allow Rest API ports, which will throw this:
```
fatal: [192.168.56.154]: FAILED! => {
	"msg": "The conditional check 'nginx_rest_api_port is defined\"' failed. The error was: template error while templating string: unexpected char u'\"' at 36. String: {% if nginx_rest_api_port is defined\" %} True {% else %} False {% endif %}

The error appears to be in '/home/test/ansible/roles/nginxinc.nginx/tasks/prerequisites/setup-selinux.yml': line 53, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: \"(Setup: SELinux: Ports) Allow Rest API ports\"
  ^ here
This one looks easy to fix. It seems that there is a value started
with a quote, and the YAML parser is expecting to see the line ended
with the same kind of quote. For instance:

    when: \"ok\" in result.stdout

Could be written as:

   when: '\"ok\" in result.stdout'

Or equivalently:

   when: \"'ok' in result.stdout\"
"
}
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/master/CONTRIBUTING.md) document
-   [x] If necessary, I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any necessary documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
