### PR TITLE
Do not fail when assert module fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.17.1 (Unreleased)
+
+ENHANCEMENTS:
+
+*   The role will no longer fail automatically on unsupported platforms, but the error message will still be displayed.
+
 ## 0.17.0 (September 20, 2020)
 
 BREAKING CHANGES:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Use `git clone https://github.com/nginxinc/ansible-role-nginx.git` to pull the l
 Platforms
 ---------
 
-The NGINX Ansible role supports all platforms supported by [NGINX Open Source](https://nginx.org/en/linux_packages.html), [NGINX Plus](https://docs.nginx.com/nginx/technical-specs/), the [NGINX Amplify agent](https://github.com/nginxinc/nginx-amplify-doc/blob/master/amplify-faq.md#21-what-operating-systems-are-supported), and [NGINX Unit](https://unit.nginx.org/installation/#official-packages) (you can also use this role to compile NGINX Open Source from source or install it on BSD systems at your own risk):
+The NGINX Ansible role supports all platforms supported by [NGINX Open Source](https://nginx.org/en/linux_packages.html), [NGINX Plus](https://docs.nginx.com/nginx/technical-specs/), the [NGINX Amplify agent](https://github.com/nginxinc/nginx-amplify-doc/blob/master/amplify-faq.md#21-what-operating-systems-are-supported), and [NGINX Unit](https://unit.nginx.org/installation/#official-packages):
 
 **NGINX Open Source**
 
@@ -156,6 +156,8 @@ Ubuntu:
   - bionic
   - focal
 ```
+
+**Note:** You can also use this role to compile NGINX Open Source from source, install NGINX Open Source on compatible yet unsupported platforms, or install NGINX Open Source on BSD systems at your own risk.
 
 Role Variables
 --------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
   when:
     - nginx_install | bool
     - (nginx_install_from == "nginx_repository" or nginx_type == "plus")
+  ignore_errors: yes
   tags: nginx_check_support
 
 - name: Set up prerequisites


### PR DESCRIPTION
### Proposed changes
This PR tweaks how the initial platform assertions are made so that even when the platform is not supported, the role will still attempt to install NGINX on your target platform. Resolves #329.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
