### PR TITLE
Tweak handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ENHANCEMENTS:
 
 *   The role will no longer fail automatically on unsupported platforms, but the error message will still be displayed.
+*   The `Check NGINX` handler now always outputs an `ok` state instead of `changed` since it's a read-only operation with no traceable changes.
 
 ## 0.17.0 (September 20, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.17.1 (Unreleased)
+## 0.17.1 (September 22, 2020)
 
 ENHANCEMENTS:
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,6 +7,7 @@
   command: nginx -t
   register: config
   ignore_errors: yes
+  changed_when: false
   listen: (Handler) Run NGINX
 
 - name: (Handler) Print NGINX error if syntax check fails
@@ -16,7 +17,7 @@
   when: config.rc != 0
   listen: (Handler) Run NGINX
 
-- name: (Handler) Start/Reload NGINX
+- name: (Handler) Start/reload NGINX
   service:
     name: nginx
     state: reloaded


### PR DESCRIPTION
### Proposed changes
The `Check NGINX` handler now always outputs an `ok` state instead of `changed` since it's a read-only operation with no traceable changes.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
