### PR TITLE
Swap order of handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.17.2 (September 24, 2020)
+
+BUG FIXES:
+
+*   Fix an issue where sometimes the role handlers will fail in distros where NGINX is not started upon installation.
+
 ## 0.17.1 (September 22, 2020)
 
 ENHANCEMENTS:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,16 @@
   systemd:
     daemon_reload: yes
 
+- name: (Handler) Start/reload NGINX
+  service:
+    name: nginx
+    state: reloaded
+    enabled: yes
+  when:
+    - nginx_start | bool
+    - not ansible_check_mode | bool
+  listen: (Handler) Run NGINX
+
 - name: (Handler) Check NGINX
   command: nginx -t
   register: config
@@ -15,16 +25,6 @@
     var: config.stderr_lines
   failed_when: config.rc != 0
   when: config.rc != 0
-  listen: (Handler) Run NGINX
-
-- name: (Handler) Start/reload NGINX
-  service:
-    name: nginx
-    state: reloaded
-    enabled: yes
-  when:
-    - nginx_start | bool
-    - not ansible_check_mode | bool
   listen: (Handler) Run NGINX
 
 - name: (Handler) Start NGINX Amplify agent


### PR DESCRIPTION
### Proposed changes
*   Fix an issue where sometimes the role handlers will fail in distros where NGINX is not started upon installation.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
