### PR TITLE
Add a conditional check to Travis for NGINX Plus builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,15 @@ jobs:
       env:
         scenario: module_centos
     - name: (Debian/Ubuntu) Install NGINX Plus
+      if: env(NGINX_CRT) is present and env(NGINX_KEY) is present
       env:
         scenario: plus
     - name: (Alpine Linux) Install NGINX Plus
+      if: env(NGINX_CRT) is present and env(NGINX_KEY) is present
       env:
         scenario: plus_alpine
     - name: (CentOS) Install NGINX Plus
+      if: env(NGINX_CRT) is present and env(NGINX_KEY) is present
       env:
         scenario: plus_centos
     - name: (Debian/Ubuntu) Install stable branch and push a config

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,15 @@ jobs:
       env:
         scenario: module_centos
     - name: (Debian/Ubuntu) Install NGINX Plus
-      if: env(NGINX_CRT) is present and env(NGINX_KEY) is present
+      if: not (type = "pull_request" and fork = "true")
       env:
         scenario: plus
     - name: (Alpine Linux) Install NGINX Plus
-      if: env(NGINX_CRT) is present and env(NGINX_KEY) is present
+      if: not (type = "pull_request" and fork = "true")
       env:
         scenario: plus_alpine
     - name: (CentOS) Install NGINX Plus
-      if: env(NGINX_CRT) is present and env(NGINX_KEY) is present
+      if: not (type = "pull_request" and fork = "true")
       env:
         scenario: plus_centos
     - name: (Debian/Ubuntu) Install stable branch and push a config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 BUG FIXES:
 
 *   Fix an issue where sometimes the role handlers will fail in distros where NGINX is not started upon installation.
+*   Prevent TravisCI from trying to build (and failing) NGINX Plus images on external PRs.
 
 ## 0.17.1 (September 22, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## 0.17.3 (Unreleased)
+
+BUG FIXES:
+
+*   Prevent TravisCI from trying to build (and failing) NGINX Plus images on external PRs.
+
 ## 0.17.2 (September 24, 2020)
 
 BUG FIXES:
 
 *   Fix an issue where sometimes the role handlers will fail in distros where NGINX is not started upon installation.
-*   Prevent TravisCI from trying to build (and failing) NGINX Plus images on external PRs.
 
 ## 0.17.1 (September 22, 2020)
 


### PR DESCRIPTION
### Proposed changes
Add a conditional check to Travis to only run NGINX Plus related tests on internal builds.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
