### PR TITLE
Implement a new syntax to specify modules to be installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.17.4 (Unreleased)
+## 0.17.4 (November 12, 2020)
 
 ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.17.4 (Unreleased)
+
+ENHANCEMENTS:
+
+*   Implement a new syntax to specify modules to be installed. You can now use the following format if you want further fine grained control over how you install modules:
+```yaml
+- name: njs  # Required
+  state: present  # Optional
+  version: =1.19.4+0.4.4-1~bionic  # Optional
+```
+The old method of specifying modules (using a list of names) still works as expected.
+
 ## 0.17.3 (November 9, 2020)
 
 ENHANCEMENTS:

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -88,7 +88,9 @@ nginx_remove_license: true
 
 # Install NGINX Modules.
 # You can select any of the modules listed below. Beware of NGINX Plus only modules (these are marked).
-# Default is no modules.
+# Format is list with either the module name or a dictionary (see njs for an example).
+# When using a dictionary, the default value for state is present, and for version it's nginx_version if specified.
+# Default is an empty list (no modules are installed).
 nginx_modules: []
   # - auth-spnego  # NGINX Plus
   # - brotli  # NGINX Plus
@@ -99,7 +101,9 @@ nginx_modules: []
   # - headers-more  # NGINX Plus
   # - image-filter
   # - lua  # NGINX Plus
-  # - njs
+  # - name: njs  # Required
+  #   state: present  # Optional
+  #   version: =1.19.4+0.4.4-1~bionic  # Optional
   # - opentracing  # NGINX Plus
   # - passenger  # NGINX Plus
   # - perl  # NGINX Plus

--- a/molecule/common/playbooks/module_converge.yml
+++ b/molecule/common/playbooks/module_converge.yml
@@ -28,6 +28,8 @@
           - brotli
           - geoip
           - image-filter
-          - njs
+          - name: njs
+            # version: =1.19.4+0.4.4-1~bionic
+            state: present
           - perl
           - xslt

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -6,27 +6,28 @@
     - ansible_facts['distribution'] == "CentOS"
     - '"geoip" in nginx_modules'
 
-- name: Install NGINX Modules
+- name: Install NGINX modules
   package:
-    name: "nginx-{{ (nginx_type == 'plus') | ternary('plus-', '') }}module-{{ item }}{{ nginx_version | default('') }}"
-    state: present
+    name: "nginx-{{ (nginx_type == 'plus') | ternary('plus-', '') }}module-{{ item.name | default(item) }}
+          {{ item.version | default(nginx_version) | default('') }}"
+    state: "{{ item.state | default('present') }}"
   loop: "{{ nginx_modules }}"
   when:
-    - (item in nginx_modules_list and nginx_type == 'opensource')
-      or (item in nginx_plus_modules_list and nginx_type == 'plus')
-    - not (item == "auth-spnego")
+    - (item.name | default(item) in nginx_modules_list and nginx_type == 'opensource')
+      or (item.name | default(item) in nginx_plus_modules_list and nginx_type == 'plus')
+    - not (item.name | default(item) == "auth-spnego")
       or not (ansible_facts['os_family'] == "Alpine" and (ansible_facts['distribution_version'] | regex_search('^[0-9]+\\.[0-9]+') is version('3.8', '==')))
-    - not (item == "geoip")
+    - not (item.name | default(item) == "geoip")
       or not ((ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] is version('8', '=='))
       or (ansible_facts['os_family'] == "FreeBSD"))
-    - not (item == "brotli")
+    - not (item.name | default(item) == "brotli")
       or not ((ansible_facts['os_family'] == "Alpine")
       or (ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] is version('8', '<'))
       or (ansible_facts['os_family'] == "Debian" and ansible_facts['distribution_major_version'] is version('9', '=='))
       or (ansible_facts['os_family'] == "Suse" and ansible_facts['distribution_major_version'] is version('12', '<'))
       or (ansible_facts['distribution'] == "Amazon")
       or (ansible_facts['distribution'] == "OracleLinux"))
-    - not (item == "geoip2") or not (ansible_facts['os_family'] == "Suse")
-    - not (item == "opentracing")
+    - not (item.name | default(item) == "geoip2") or not (ansible_facts['os_family'] == "Suse")
+    - not (item.name | default(item) == "opentracing")
       or not ((ansible_facts['os_family'] == "Suse" and ansible_facts['distribution_major_version'] is version('12', '=='))
       or (ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] is version('6', '==')))

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -8,7 +8,7 @@
 
 - name: Install NGINX modules
   package:
-    name: "nginx-{{ (nginx_type == 'plus') | ternary('plus-', '') }}module-{{ item.name | default(item) }}
+    name: "nginx-{{ (nginx_type == 'plus') | ternary('plus-', '') }}module-{{ item.name | default(item) }}\
           {{ item.version | default(nginx_version) | default('') }}"
     state: "{{ item.state | default('present') }}"
   loop: "{{ nginx_modules }}"


### PR DESCRIPTION
### Proposed changes
You can now use the following format if you want further fine grained control over how you install modules:
```yaml
- name: njs  # Required
  state: present  # Optional
  version: =1.19.4+0.4.4-1~bionic  # Optional
```
The old method of specifying modules (using a list of names) still works as expected.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
