### PR TITLE
SELinux state should now be correctly set back to `enforcing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ ENHANCEMENTS:
 
 Switch NGINX keysites and OSS default repository data from a dictionary to individual variables to prevent potential issues arisen from Jinja2 dictionary run-time evaluations.
 
+BUG FIXES:
+
+Fix issue whereas SELinux state would not be correctly set back to `enforcing` when `nginx_selinux: true`.
+
 ## 0.18.0 (November 13, 2020)
 
 BREAKING CHANGES:

--- a/tasks/prerequisites/setup-selinux.yml
+++ b/tasks/prerequisites/setup-selinux.yml
@@ -21,8 +21,6 @@
   selinux:
     state: permissive
     policy: targeted
-  changed_when: false
-  when: ansible_facts['selinux']['mode'] == "enforcing"
 
 - name: Allow SELinux HTTP network connections
   seboolean:
@@ -96,7 +94,4 @@
   selinux:
     state: enforcing
     policy: targeted
-  changed_when: false
-  when:
-    - nginx_selinux_enforcing | bool
-    - ansible_facts['selinux']['mode'] == "permissive"
+  when: nginx_selinux_enforcing | bool


### PR DESCRIPTION
### Proposed changes
Fix issue whereas SELinux state would not be correctly set back to `enforcing` when `nginx_selinux: true`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
