### PR TITLE
Do not run Molecule CI/CD workflow when creating a new release

### DIFF
--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -1,9 +1,7 @@
 ---
 name: Ansible Galaxy import
 on:
-  push:
-    tags:
-      - '*'
+  release:
 jobs:
   galaxy:
     name: Galaxy
@@ -15,7 +13,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: 3.x
 
       - name: Install Ansible
         run: pip3 install ansible-base==2.10.3

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -45,14 +45,14 @@ jobs:
           pip3 install ansible==2.10.3
           pip3 install ansible-lint==4.3.7
           pip3 install yamllint==1.25.0
-          pip3 install 'molecule[docker]'==3.2.1
+          pip3 install "molecule[docker]"==3.2.1
           pip3 install docker==4.4.0
 
       - name: Run Molecule tests
         run: molecule test -s ${{ matrix.scenario }}
-        if: contains(${{ matrix.scenario }}, 'plus') && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+        if: contains(${{ matrix.scenario }}, "plus") && !(github.event_name == "pull_request" && github.event.pull_request.head.repo.fork)
         env:
-          PY_COLORS: '1'
-          ANSIBLE_FORCE_COLOR: '1'
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
           NGINX_CRT: ${{ secrets.NGINX_CRT }}
           NGINX_KEY: ${{ secrets.NGINX_KEY }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -2,9 +2,13 @@
 name: Molecule CI/CD
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
+    ignore-tags:
+      - "*"
   schedule:
     - cron: "0 0 1 * *"
 jobs:
@@ -33,7 +37,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: 3.x
 
       - name: Install Molecule dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ BREAKING CHANGES:
 
 ENHANCEMENTS:
 
-The GitHub actions Molecule CI/CD (`molecule.yml`) workflow is no longer run on a new release (this is not necessary since it already runs on every push).
+The GitHub actions Molecule CI/CD workflow is no longer run on a new release (this is not necessary since it already runs on every push).
 
 ## 0.18.2 (December 22, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ BREAKING CHANGES:
 
 **The NGINX configuration functionalities included in this role have been removed as of release 0.19.0.** There now is a separate role to manage and create NGINX configurations available [here](https://github.com/nginxinc/ansible-role-nginx-config). Any new issues or PRs related to configuring NGINX should be submitted in the new NGINX configuration Ansible role repository. New issues or PRs related to configuring NGINX submitted in this repository will not be worked on.
 
+ENHANCEMENTS:
+
+The GitHub actions Molecule CI/CD (`molecule.yml`) workflow is no longer run on a new release (this is not necessary since it already runs on every push).
+
 ## 0.18.2 (December 22, 2020)
 
 ENHANCEMENTS:


### PR DESCRIPTION
### Proposed changes
The GitHub actions Molecule CI/CD workflow is no longer run on a new release (this is not necessary since it already runs on every push).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
