### PR TITLE
Update Molecule CI/CD workflow to avoid running `plus` tests on external PRs

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -32,14 +32,17 @@ jobs:
           - source_centos
     steps:
       - name: Check out the codebase
+        if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"
         uses: actions/checkout@v2
 
       - name: Set up Python 3
+        if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
 
       - name: Install Molecule dependencies
+        if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"
         run: |
           pip3 install ansible-base==2.10.3
           pip3 install ansible==2.10.3
@@ -49,8 +52,8 @@ jobs:
           pip3 install docker==4.4.0
 
       - name: Run Molecule tests
+        if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"
         run: molecule test -s ${{ matrix.scenario }}
-        if: contains(${{ matrix.scenario }}, "plus") && !(github.event_name == "pull_request" && github.event.pull_request.head.repo.fork)
         env:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ BREAKING CHANGES:
 ENHANCEMENTS:
 
 *   The GitHub actions Molecule CI/CD workflow is no longer run on a new release (this is not necessary since it already runs on every push).
-*   The GitHub actions Molecule CI/CD workflow should now correctly avoid running 'Plus' related tests on external PRs.
+*   The GitHub actions Molecule CI/CD workflow should now correctly avoid running 'plus' related tests on external PRs.
 
 ## 0.18.2 (December 22, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.19.0 (Unreleased)
+## 0.19.1 (Unreleased)
+
+ENHANCEMENTS:
+
+The GitHub actions Molecule CI/CD workflow should now correctly avoid running 'plus' related tests on external PRs.
+
+## 0.19.0 (December 23, 2020)
 
 BREAKING CHANGES:
 
@@ -8,8 +14,7 @@ BREAKING CHANGES:
 
 ENHANCEMENTS:
 
-*   The GitHub actions Molecule CI/CD workflow is no longer run on a new release (this is not necessary since it already runs on every push).
-*   The GitHub actions Molecule CI/CD workflow should now correctly avoid running 'plus' related tests on external PRs.
+The GitHub actions Molecule CI/CD workflow is no longer run on a new release (this is not necessary since it already runs on every push).
 
 ## 0.18.2 (December 22, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ BREAKING CHANGES:
 
 ENHANCEMENTS:
 
-The GitHub actions Molecule CI/CD workflow is no longer run on a new release (this is not necessary since it already runs on every push).
+*   The GitHub actions Molecule CI/CD workflow is no longer run on a new release (this is not necessary since it already runs on every push).
+*   The GitHub actions Molecule CI/CD workflow should now correctly avoid running 'Plus' related tests on external PRs.
 
 ## 0.18.2 (December 22, 2020)
 


### PR DESCRIPTION
### Proposed changes
The GitHub actions Molecule CI/CD workflow should now correctly avoid running 'plus' related tests on external PRs.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
