### PR TITLE
Add support for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,13 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+---
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "daily"
     target-branch: "implement-dependabot"
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/.github/workflows"
     schedule:
       interval: "daily"
     target-branch: "implement-dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    target-branch: "implement-dependabot"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "implement-dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "implement-dependabot"
   - package-ecosystem: "pip"
     directory: "/.github/workflows"
     schedule:
       interval: "daily"
-    target-branch: "implement-dependabot"

--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -2,6 +2,8 @@
 name: Ansible Galaxy import
 on:
   release:
+    types:
+      - published
 jobs:
   galaxy:
     name: Galaxy

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -41,9 +41,6 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: test dir
-        run: echo $pwd
-
       - name: Install Molecule dependencies
         if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"
         run: pip3 install -r .github/workflows/requirements.txt

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -43,13 +43,7 @@ jobs:
 
       - name: Install Molecule dependencies
         if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"
-        run: |
-          pip3 install ansible-base==2.10.4
-          pip3 install ansible==2.10.5
-          pip3 install ansible-lint==4.3.7
-          pip3 install yamllint==1.25.0
-          pip3 install "molecule[docker]"==3.2.2
-          pip3 install docker==4.4.1
+        run: pip3 install -r requirements.txt
 
       - name: Run Molecule tests
         if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -41,9 +41,12 @@ jobs:
         with:
           python-version: 3.x
 
+      - name: test dir
+        run: echo $pwd
+
       - name: Install Molecule dependencies
         if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"
-        run: pip3 install -r requirements.txt
+        run: pip3 install -r .github/workflows/requirements.txt
 
       - name: Run Molecule tests
         if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,0 +1,6 @@
+ansible-base==2.10.4
+ansible==2.10.5
+ansible-lint==4.3.7
+yamllint==1.25.0
+"molecule[docker]"==3.2.2
+docker==4.4.1

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -2,5 +2,5 @@ ansible-base==2.10.4
 ansible==2.10.5
 ansible-lint==4.3.7
 yamllint==1.25.0
-"molecule[docker]"==3.2.2
+molecule[docker]==3.2.2
 docker==4.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.19.2 (Unreleased)
+
+FEATURES:
+
+Add support for Dependabot.
+
+ENHANCEMENTS:
+
+*   Only run GitHub actions Galaxy CI/CD workflow when a new release is published.
+*   Update list of supported platforms.
+
 ## 0.19.1 (January 11, 2021)
 
 ENHANCEMENTS:

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ SUSE/SLES:
 Ubuntu:
   - xenial
   - bionic
-  - eoan
   - focal
+  - groovy
 ```
 
 ### NGINX Plus
@@ -88,9 +88,8 @@ Debian:
   - buster
 FreeBSD:
   - 11.2+
-  - 12
+  - 12.1+
 Oracle Linux:
-  - 6.5+
   - 7.4+
 Red Hat:
   - 7.4+
@@ -101,8 +100,8 @@ SUSE/SLES:
 Ubuntu:
   - xenial
   - bionic
-  - eoan
   - focal
+  - groovy
 ```
 
 ### NGINX Amplify Agent

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,12 +30,13 @@ galaxy_info:
     - name: FreeBSD
       versions:
         - 11.2
-        - 12.0
+        - 12.1
     - name: Ubuntu
       versions:
         - xenial
         - bionic
         - focal
+        - groovy
     - name: SLES
       versions:
         - 12


### PR DESCRIPTION
### Proposed changes
*   Add support for Dependabot.
*   Only run GitHub actions Galaxy CI/CD workflow when a new release is published.
*   Update list of supported platforms.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
