### PR TITLE
Incorrect setup of Systemd restart value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ ENHANCEMENTS:
 *   Minor GitHub template tweaks, including the creation of a SECURITY doc.
 *   Update list of supported platforms.
 *   Update Ansible base to `2.10.5`, Molecule to `3.2.3`, yamllint to `1.26.0` and Docker Python SDK to `4.4.4`.
+*   Override of systemd `Restart` value by using proper `nginx_service_restart` variable.
 
 BUG FIXES:
 

--- a/templates/services/nginx.service.override.conf.j2
+++ b/templates/services/nginx.service.override.conf.j2
@@ -2,6 +2,9 @@
 {% if nginx_service_timeoutstopsec is defined %}
 TimeoutStopSec={{ nginx_service_timeoutstopsec | default(90) }}
 {% endif %}
+{% if nginx_service_restartonfailure is defined %}
+Restart=on-failure
+{% endif %}
 {% if nginx_service_restart is defined %}
 Restart={{ nginx_service_restart }}
 {% endif %}

--- a/templates/services/nginx.service.override.conf.j2
+++ b/templates/services/nginx.service.override.conf.j2
@@ -2,8 +2,8 @@
 {% if nginx_service_timeoutstopsec is defined %}
 TimeoutStopSec={{ nginx_service_timeoutstopsec | default(90) }}
 {% endif %}
-{% if nginx_service_restartonfailure is defined %}
-Restart=on-failure
+{% if nginx_service_restart is defined %}
+Restart={{ nginx_service_restart }}
 {% endif %}
 {% if nginx_service_restartsec is defined %}
 RestartSec={{ nginx_service_restartsec }}


### PR DESCRIPTION
### Proposed changes

This PR is intended as the fix for incorrect setup of systemd `Restart` value.

Current handling of the value within [nginx.service.override.conf.j2](https://github.com/nginxinc/ansible-role-nginx/blob/main/templates/services/nginx.service.override.conf.j2):

```
...
{% if nginx_service_restartonfailure is defined %}
Restart=on-failure
{% endif %}
...
```

`nginx_service_restartonfailure` variable is not defined or mentioned in whole repository, but will keep its usage for backward compatibility and possible use of external value.

My proposed change works with `nginx_service_restart` variable that is already prepared in [systemd.yml](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/systemd.yml) variable file:

```
...
# Set the restart policy for systemd systems
# Values = no (default), on-failure, on-abnormal, on-watchdog, on-abort, always
# [Service]
# Restart=on-failure
# Default is to comment this out
# nginx_service_restart: on-failure
...
```

### Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
