### PR TITLE
Change NGINX config check handler directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-Add `state` parameter to package module in Molecule verification tests.
+*   Add `state` parameter to package module in Molecule verification tests.
+*   Change directory when running the NGINX configuration check handler to prevent edge errors related to NGINX permissions.
 
 ## 0.19.1 (January 11, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ ENHANCEMENTS:
 BUG FIXES:
 
 *   Add `state` parameter to package module in Molecule verification tests.
-*   Change directory when running the NGINX configuration check handler to prevent edge errors related to NGINX permissions.
+*   Change the command directory when running the NGINX configuration check handler to prevent edge case errors when the handler is run from a directory that the NGINX process' user does not have access to.
 
 ## 0.19.1 (January 11, 2021)
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,6 +15,8 @@
 
 - name: (Handler) Check NGINX
   command: nginx -t
+  args:
+    chdir: /etc/nginx/
   register: config_check
   ignore_errors: yes
   check_mode: no


### PR DESCRIPTION
### Proposed changes
Change the command directory when running the NGINX configuration check handler to prevent edge case errors when the handler is run from a directory that the NGINX process' user does not have access to.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
