### PR TITLE
Add Alpine 3.13 to the list of NGINX Plus supported platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ FEATURES:
 ENHANCEMENTS:
 
 *   Only run GitHub actions Galaxy CI/CD workflow when a new release is published.
+*   Add Alpine `3.13` to the list of NGINX Plus supported platforms.
 *   Specify GitHub actions Ubuntu release.
 *   Minor GitHub template tweaks, including the creation of a SECURITY doc.
 *   Add Molecule NGINX OSS tests for Alpine 3.13, remove Molecule tests for Debian stretch, and update list of supported platforms.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Alpine:
   - 3.10
   - 3.11
   - 3.12
+  - 3.13
 Amazon Linux:
   - 2018.03
 Amazon Linux 2:

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -27,6 +27,13 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/sbin/init"
+  - name: alpine-3.13
+    image: alpine:3.13
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
   - name: centos-7
     image: centos:7
     dockerfile: ../common/Dockerfile.j2

--- a/tasks/opensource/install-source.yml
+++ b/tasks/opensource/install-source.yml
@@ -297,7 +297,7 @@
 
     - name: Set NGINX stable version 1/2
       set_fact:
-        nginx_version: "{{ nginx_versions.content | regex_search('stable[^ ]*') | regex_replace('stable', 'release') }}"
+        nginx_version: "{{ nginx_versions.content | regex_search('stable[^<]*') | regex_replace('stable', 'release') }}"
       when: nginx_branch == "stable"
 
     - name: Set NGINX stable version 2/2


### PR DESCRIPTION
### Proposed changes
Per title, add Alpine 3.13 to the list of NGINX Plus supported platforms.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
