### PR TITLE
Update NGINX Plus repository

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -72,7 +72,7 @@ autolabeler:
     branch:
       - "/docs\/.+/"
     files:
-      - "!(changelog).md"
+      - "**/!(changelog).md"
     title:
       - "/docs/i"
       - "/documentation/i"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -72,19 +72,13 @@ autolabeler:
     branch:
       - "/docs\/.+/"
     files:
-      - "*.md"
+      - "!(changelog).md"
     title:
       - "/docs/i"
       - "/documentation/i"
   - label: "dependencies"
     files:
       - ".github/workflows/requirements/*"
-    branch:
-      - "/bump\/.+/"
-      - "/update\/.+/"
-    title:
-      - "/bump/i"
-      - "/update/i"
 template: |
   👾 *Help make the NGINX Ansible role better by participating in our [survey](https://forms.office.com/Pages/ResponsePage.aspx?id=L_093Ttq0UCb4L-DJ9gcUKLQ7uTJaE1PitM_37KR881UM0NCWkY5UlE5MUYyWU1aTUcxV0NRUllJSC4u)!* 👾
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 BREAKING CHANGES:
 
-*   Updated NGINX Plus repository to the new repository to be used starting with R25. This might cause some issues when running the role on an instance that already has NGINX Plus installed. We recommend uninstalling NGINX using `nginx_state: absent` and `nginx_remove_license: true` before attempting to reinstall NGINX Plus.
-*   NGINX Plus modsecurity module is no longer supported by this role. Use release `0.19.2` if you still wish to install modsecurity. Installing NGINX Plus using `0.19.2` will no longer work once R25 is released.
+*   The NGINX Plus repository has been updated. This might cause some issues when running the role on an instance that already has NGINX Plus installed. **Starting with NGINX Plus R25, you will need to install NGINX Plus using release `0.20.0`. If you are trying to install R23, please use release `0.19.2`. NGINX Plus R24 should work with both release `0.19.2` and `0.20.0`.**
+*   The NGINX Plus modsecurity module is no longer supported by this role. Until NGINX Plus R25 is released, you might keep using release `0.19.2` if you wish to install modsecurity.
 
 ## 0.19.2 (April 28, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.20.0 (Unreleased)
+
+BREAKING CHANGES:
+
+*   Updated NGINX Plus repository to the new repository to be used starting with R25. This might cause some issues when running the role on an instance that already has NGINX Plus installed. We recommend uninstalling NGINX using `nginx_state: absent` and `nginx_remove_license: true` before attempting to reinstall NGINX Plus.
+*   NGINX Plus modsecurity module is no longer supported by this role. Use release `0.19.2` if you still wish to install modsecurity. Installing NGINX Plus using `0.19.2` will no longer work once R25 is released.
+
 ## 0.19.2 (April 28, 2021)
 
 FEATURES:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ To suggest an enhancement, please create an issue on GitHub with the label `enha
 ### Open a Pull Request
 
 *   Fork the repo, create a branch, implement your changes, add any relevant Molecule tests, submit a PR when your changes are **tested** (using Molecule) and ready for review.
-*   Fill in [our pull request template](https://github.com/nginxinc/ansible-role-nginx/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
+*   Fill in [our pull request template](https://github.com/nginxinc/ansible-role-nginx/blob/main/.github/pull_request_template.md).
 
 Note: if you’d like to implement a new feature, please consider creating a feature request issue first to start a discussion about the feature.
 

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -21,7 +21,6 @@
           - headers-more
           - image-filter
           - lua
-          - modsecurity
           - njs
           - opentracing
           - passenger

--- a/tasks/plus/install-debian.yml
+++ b/tasks/plus/install-debian.yml
@@ -4,10 +4,10 @@
     path: /etc/apt/apt.conf.d/90nginx
     create: yes
     block: |
-      Acquire::https::plus-pkgs.nginx.com::Verify-Peer "true";
-      Acquire::https::plus-pkgs.nginx.com::Verify-Host "true";
-      Acquire::https::plus-pkgs.nginx.com::SslCert     "/etc/ssl/nginx/nginx-repo.crt";
-      Acquire::https::plus-pkgs.nginx.com::SslKey      "/etc/ssl/nginx/nginx-repo.key";
+      Acquire::https::{{ (nginx_repository | default(nginx_plus_default_repository_debian)) | regex_search('(?<=https://)[^/]*') }}::Verify-Peer "true";
+      Acquire::https::{{ (nginx_repository | default(nginx_plus_default_repository_debian)) | regex_search('(?<=https://)[^/]*') }}::Verify-Host "true";
+      Acquire::https::{{ (nginx_repository | default(nginx_plus_default_repository_debian)) | regex_search('(?<=https://)[^/]*') }}::SslCert     "/etc/ssl/nginx/nginx-repo.crt";
+      Acquire::https::{{ (nginx_repository | default(nginx_plus_default_repository_debian)) | regex_search('(?<=https://)[^/]*') }}::SslKey      "/etc/ssl/nginx/nginx-repo.key";
     state: "{{ nginx_license_status | default ('present') }}"
     mode: 0444
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -31,14 +31,14 @@ nginx_default_repository_suse: "https://nginx.org/packages/{{ (nginx_branch == '
                                 sles/{{ ansible_facts['distribution_major_version'] }}"
 
 # Default NGINX Plus repositories
-nginx_plus_default_repository_alpine: "https://plus-pkgs.nginx.com/alpine/v{{ ansible_facts['distribution_version'] | regex_search('^[0-9]+\\.[0-9]+') }}/main"
-nginx_plus_default_repository_amazon: "https://plus-pkgs.nginx.com/amzn{{ (ansible_facts['distribution_major_version'] is version('2', '==')) | ternary('2', '') }}/$releasever/$basearch"
-nginx_plus_default_repository_debian: "deb [arch=amd64] https://plus-pkgs.nginx.com/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] }} nginx-plus"
-nginx_plus_default_repository_freebsd: "https://plus-pkgs.nginx.com/freebsd/${ABI}/latest"
-nginx_plus_default_repository_redhat: "https://plus-pkgs.nginx.com/{{ (ansible_facts['distribution'] == 'CentOS') | ternary('centos', 'rhel') }}/\
+nginx_plus_default_repository_alpine: "https://pkgs.nginx.com/plus/alpine/v{{ ansible_facts['distribution_version'] | regex_search('^[0-9]+\\.[0-9]+') }}/main"
+nginx_plus_default_repository_amazon: "https://pkgs.nginx.com/plus/amzn{{ (ansible_facts['distribution_major_version'] is version('2', '==')) | ternary('2', '') }}/$releasever/$basearch"
+nginx_plus_default_repository_debian: "deb [arch=amd64] https://pkgs.nginx.com/plus/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] }} nginx-plus"
+nginx_plus_default_repository_freebsd: "https://pkgs.nginx.com/plus/freebsd/${ABI}/latest"
+nginx_plus_default_repository_redhat: "https://pkgs.nginx.com/plus/{{ (ansible_facts['distribution'] == 'CentOS') | ternary('centos', 'rhel') }}/\
                                       {{ (ansible_facts['distribution_version'] is version('7.4', '>=')
                                       and ansible_facts['distribution_version'] is version('8', '<')) | ternary('7.4', ansible_facts['distribution_major_version']) }}/$basearch/"
-nginx_plus_default_repository_suse: "https://plus-pkgs.nginx.com/sles/{{ ansible_facts['distribution_major_version'] }}\
+nginx_plus_default_repository_suse: "https://pkgs.nginx.com/plus/sles/{{ ansible_facts['distribution_major_version'] }}\
                                     ?ssl_clientcert=/etc/ssl/nginx/nginx-repo-bundle.crt&ssl_verify=peer"
 
 # Alpine dependencies
@@ -78,6 +78,6 @@ nginx_modules_list: [
 
 # Supported NGINX Plus modules
 nginx_plus_modules_list: [
-  'auth-spnego', 'brotli', 'cookie-flag', 'encrypted-session', 'geoip', 'geoip2', 'headers-more', 'image-filter', 'lua',
-  'modsecurity', 'njs', 'opentracing', 'passenger', 'perl', 'prometheus', 'rtmp', 'subs-filter', 'xslt',
+  'auth-spnego', 'brotli', 'cookie-flag', 'encrypted-session', 'geoip', 'geoip2', 'headers-more', 'image-filter',
+  'lua', 'njs', 'opentracing', 'passenger', 'perl', 'prometheus', 'rtmp', 'subs-filter', 'xslt',
 ]


### PR DESCRIPTION
### Proposed changes
*   The NGINX Plus repository has been updated. This might cause some issues when running the role on an instance that already has NGINX Plus installed. **Starting with NGINX Plus R25, you will need to install NGINX Plus using release `0.20.0`. If you are trying to install R23, please use release `0.19.2`. NGINX Plus R24 should work with both release `0.19.2` and `0.20.0`.**
*   The NGINX Plus modsecurity module is no longer supported by this role. Until NGINX Plus R25 is released, you might keep using release `0.19.2` if you wish to install modsecurity.


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
