### PR TITLE
Update the URL used to fetch the latest NGINX source version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ BREAKING CHANGES:
 *   The NGINX Plus repository has been updated. This might cause some issues when running the role on an instance that already has NGINX Plus installed. **Starting with NGINX Plus R25, you will need to install NGINX Plus using release `0.20.0`. If you are trying to install R23, please use release `0.19.2`. NGINX Plus R24 should work with both release `0.19.2` and `0.20.0`.**
 *   The NGINX Plus modsecurity module is no longer supported by this role. Until NGINX Plus R25 is released, you might keep using release `0.19.2` if you wish to install modsecurity.
 
+BUG FIXES:
+
+Change the url used to grep the latest NGINX version when installing from source. This should avoid the source install failing whenever the `stable` release is higher than the latest `mainline`.
+
 ## 0.19.2 (April 28, 2021)
 
 FEATURES:

--- a/tasks/opensource/install-source.yml
+++ b/tasks/opensource/install-source.yml
@@ -292,7 +292,7 @@
 
     - name: Set NGINX version
       set_fact:
-        nginx_download_name: "{{ 'nginx-' + (nginx_versions.content | regex_search('([0-9]+\\.){2}[0-9]+')) }}"
+        nginx_version: "{{ 'nginx-' + (nginx_versions.content | regex_search('([0-9]+\\.){2}[0-9]+')) }}"
 
     - name: Check for NGINX install
       stat:
@@ -308,8 +308,8 @@
   block:
     - name: Download NGINX
       get_url:
-        url: "https://nginx.org/download/{{ nginx_download_name }}.tar.gz"
-        dest: "/tmp/{{ nginx_download_name }}.tar.gz"
+        url: "https://nginx.org/download/{{ nginx_version }}.tar.gz"
+        dest: "/tmp/{{ nginx_version }}.tar.gz"
         mode: 0600
         validate_certs: "{{ (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] is version('6', '=='))
                         | ternary('no', 'yes') }}"

--- a/tasks/opensource/install-source.yml
+++ b/tasks/opensource/install-source.yml
@@ -283,31 +283,16 @@
   block:
     - name: Fetch NGINX version
       uri:
-        url: https://trac.nginx.org/nginx/browser
+        url: https://version.nginx.com/nginx/{{ nginx_branch }}
         return_content: yes
         validate_certs: "{{ (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] is version('6', '=='))
                         | ternary('no', 'yes') }}"
       check_mode: no
       register: nginx_versions
 
-    - name: Set NGINX mainline version
+    - name: Set NGINX version
       set_fact:
-        nginx_version: "{{ nginx_versions.content | regex_search('release[^<]*') | regex_replace('release', 'nginx') }}"
-      when: nginx_branch == "mainline"
-
-    - name: Set NGINX stable version 1/2
-      set_fact:
-        nginx_version: "{{ nginx_versions.content | regex_search('stable[^<]*') | regex_replace('stable', 'release') }}"
-      when: nginx_branch == "stable"
-
-    - name: Set NGINX stable version 2/2
-      set_fact:
-        nginx_version: "{{ nginx_versions.content | regex_search(nginx_version + '[^<]*') | regex_replace('release', 'nginx') }}"
-      when: nginx_branch == "stable"
-
-    - name: Set NGINX download filename
-      set_fact:
-        nginx_download_name: "{{ nginx_version }}"
+        nginx_download_name: "{{ 'nginx-' + (nginx_versions.content | regex_search('([0-9]+\\.){2}[0-9]+')) }}"
 
     - name: Check for NGINX install
       stat:


### PR DESCRIPTION
### Proposed changes
Change the url used to grep the latest NGINX version when installing from source. This should avoid the source install failing whenever the `stable` release is higher than the latest `mainline`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
