### PR TITLE
Replace Ansible base with Ansible core

### DIFF
--- a/.github/workflows/requirements/requirements_galaxy.txt
+++ b/.github/workflows/requirements/requirements_galaxy.txt
@@ -1,1 +1,1 @@
-ansible-base==2.10.9
+ansible-core==2.11.1

--- a/.github/workflows/requirements/requirements_molecule.txt
+++ b/.github/workflows/requirements/requirements_molecule.txt
@@ -1,4 +1,4 @@
-ansible-base==2.10.9
+ansible-core==2.11.1
 jinja2==3.0.1
 ansible-lint==5.0.11
 yamllint==1.26.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ BREAKING CHANGES:
 *   The NGINX Plus repository has been updated. This might cause some issues when running the role on an instance that already has NGINX Plus installed. **Starting with NGINX Plus R25, you will need to install NGINX Plus using release `0.20.0`. If you are trying to install R23, please use release `0.19.2`. NGINX Plus R24 should work with both release `0.19.2` and `0.20.0`.**
 *   The NGINX Plus modsecurity module is no longer supported by this role. Until NGINX Plus R25 is released, you might keep using release `0.19.2` if you wish to install modsecurity.
 
+ENHANCEMENTS:
+
+Replace Ansible base with Ansible core. Ansible core will be the "core" Ansible release moving forward from Ansible `2.11`.
+
 ## 0.19.2 (April 28, 2021)
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ With the advent of Ansible collections and the release of the [NGINX Core Ansibl
 
 ### Ansible
 
-*   This role is developed and tested with [maintained](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html) versions of Ansible base (bigger than `2.10`) and Ansible (bigger than `2.9.10`).
+*   This role is developed and tested with [maintained](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html) versions of Ansible core (above `2.11`) and Ansible (above `2.9.10`).
 *   When using Ansible base, you will also need to install the following collections:
     ```yaml
     ---


### PR DESCRIPTION
### Proposed changes
Replace Ansible base with Ansible core. Ansible core will be the "core" Ansible release moving forward from Ansible `2.11`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
