### PR TITLE
Ignore Ansible lint warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   when:
     - nginx_install | bool
     - (nginx_install_from == "nginx_repository" or nginx_type == "plus")
-  ignore_errors: true
+  ignore_errors: true  # noqa ignore-errors
   tags: nginx_check_support
 
 - name: Set up prerequisites


### PR DESCRIPTION
### Proposed changes
Ignore Ansible lint warning for `ignore_errors` on a specific instance where `ignore_errors` is required to achieve the desired outcome.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
