### PR TITLE
Add 'nginx_manage_repo' feature flag and defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.21.0 (Unreleased)
+
+FEATURES:
+
+*   Add a `nginx_manage_repo` feature flag which allows disabling NGINX repo management by this role.
+
 ## 0.20.0 (June 9, 2021)
 
 BREAKING CHANGES:

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -34,6 +34,12 @@ nginx_type: opensource
 # Default is present.
 nginx_state: present
 
+# Specify whether or not you want to manage the Nginx repositories.
+# Using 'true' will manage Nginx repositories.
+# Using 'false' will not manage the Nginx repositories, allowing them to be managed through other means.
+# Default is true
+nginx_manage_repo: true
+
 # Specify repository origin for NGINX Open Source.
 # Options are 'nginx_repository', 'source' or 'os_repository'.
 # Only works if 'nginx_type' is set to 'opensource'.

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -34,9 +34,9 @@ nginx_type: opensource
 # Default is present.
 nginx_state: present
 
-# Specify whether or not you want to manage the Nginx repositories.
-# Using 'true' will manage Nginx repositories.
-# Using 'false' will not manage the Nginx repositories, allowing them to be managed through other means.
+# Specify whether or not you want to manage the NGINX repositories.
+# Using 'true' will manage NGINX repositories.
+# Using 'false' will not manage the NGINX repositories, allowing them to be managed through other means.
 # Default is true
 nginx_manage_repo: true
 

--- a/tasks/opensource/install-alpine.yml
+++ b/tasks/opensource/install-alpine.yml
@@ -4,6 +4,7 @@
     path: /etc/apk/repositories
     insertafter: EOF
     line: "{{ nginx_repository | default(nginx_default_repository_alpine) }}"
+  when: nginx_manage_repo | bool
 
 - name: (Alpine Linux) Install NGINX
   apk:

--- a/tasks/opensource/install-debian.yml
+++ b/tasks/opensource/install-debian.yml
@@ -6,6 +6,7 @@
     update_cache: true
     mode: 0644
   loop: "{{ nginx_repository | default(nginx_default_repository_debian) }}"
+  when: nginx_manage_repo | bool
 
 - name: (Debian/Ubuntu) Install NGINX
   apt:

--- a/tasks/opensource/install-redhat.yml
+++ b/tasks/opensource/install-redhat.yml
@@ -7,7 +7,9 @@
     enabled: true
     gpgcheck: true
     mode: 0644
-  when: ansible_facts['distribution_major_version'] is version('8', '<')
+  when:
+    - ansible_facts['distribution_major_version'] is version('8', '<')
+    - nginx_manage_repo | bool
 
 - name: (CentOS/RHEL 8) Configure NGINX repository
   blockinfile:
@@ -21,7 +23,9 @@
       name = NGINX Repository
       module_hotfixes = true
     mode: 0644
-  when: ansible_facts['distribution_major_version'] is version('8', '==')
+  when:
+    - ansible_facts['distribution_major_version'] is version('8', '==')
+    - nginx_manage_repo | bool
 
 - name: (CentOS/RHEL) Install NGINX
   yum:

--- a/tasks/opensource/install-suse.yml
+++ b/tasks/opensource/install-suse.yml
@@ -3,6 +3,7 @@
   zypper_repository:
     name: "nginx-{{ nginx_branch }}"
     repo: "{{ nginx_repository | default(nginx_default_repository_suse) }}"
+  when: nginx_manage_repo | bool
 
 - name: (SLES) Install NGINX
   zypper:

--- a/tasks/plus/install-alpine.yml
+++ b/tasks/plus/install-alpine.yml
@@ -5,6 +5,7 @@
     insertafter: EOF
     line: "{{ nginx_repository | default(nginx_plus_default_repository_alpine) }}"
     state: "{{ nginx_license_status | default ('present') }}"
+  when: nginx_manage_repo | bool
 
 - name: (Alpine Linux) Install NGINX Plus
   apk:

--- a/tasks/plus/install-debian.yml
+++ b/tasks/plus/install-debian.yml
@@ -18,6 +18,7 @@
     update_cache: false
     state: "{{ nginx_license_status | default ('present') }}"
     mode: 0644
+  when: nginx_manage_repo | bool
 
 - name: (Debian/Ubuntu) Install NGINX Plus
   apt:

--- a/tasks/plus/install-freebsd.yml
+++ b/tasks/plus/install-freebsd.yml
@@ -20,6 +20,7 @@
       }
     state: "{{ nginx_license_status | default ('present') }}"
     mode: 0644
+  when: nginx_manage_repo | bool
 
 - name: (FreeBSD) Install NGINX Plus
   pkgng:

--- a/tasks/plus/install-redhat.yml
+++ b/tasks/plus/install-redhat.yml
@@ -11,6 +11,7 @@
     gpgcheck: true
     state: "{{ nginx_license_status | default ('present') }}"
     mode: 0644
+  when: nginx_manage_repo | bool
 
 - name: (Amazon Linux/CentOS/Oracle Linux/RHEL) Install NGINX Plus
   yum:

--- a/tasks/plus/install-suse.yml
+++ b/tasks/plus/install-suse.yml
@@ -11,6 +11,7 @@
     name: nginx-plus
     repo: "{{ nginx_repository | default(nginx_plus_default_repository_suse) }}"
     state: "{{ nginx_license_status | default ('present') }}"
+  when: nginx_manage_repo | bool
 
 - name: (SLES) Install NGINX Plus
   zypper:


### PR DESCRIPTION
### Proposed changes

This change adds a `nginx_manage_repo` boolean which can be used to disable Nginx repo management by this role.

This feature flag addresses edge-cases where Nginx' repositories are managed by other means and should not be configured by this role in order to install Nginx. The default behavior of the role is unaltered.

### Checklist

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)

Sidenote on Molecule tests, as a test for setting `nginx_manage_repo` to `false`  would effectively require current tests to be disabled, and as the default behavior is not altered, no additional tests have been added. 