### PR TITLE
Add 'nginx_install_epel_release' feature flag to disable the installation of epel-release if so desired

### DIFF
--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -40,6 +40,12 @@ nginx_state: present
 # Default is nginx_repository.
 nginx_install_from: nginx_repository
 
+# Specify whether or not you want this role to install the epel-release package.
+# Using 'true' will install epel-release if other criteria are met.
+# Using 'false' will not install epel-release.
+# Default is true.
+nginx_install_epel_release: true
+
 # Specify source install options for NGINX Open Source.
 # Options represent whether to install from source also or to install from packages (default).
 # These only apply if 'nginx_install_from' is set to 'source'.

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -5,6 +5,7 @@
   when:
     - ansible_facts['distribution'] == "CentOS"
     - '"geoip" in nginx_modules'
+    - nginx_install_epel_release | bool
 
 - name: Install NGINX modules
   package:


### PR DESCRIPTION
### Proposed changes

This change adds a `nginx_install_epel_release` feature flag which allows `epel-release` to not be installed by this role if so desired.

This feature flag addresses a need where the epel repository config is managed by other means and should not be configured by this role in order to install Nginx or it's modules. The default behavior of the role is unaltered.


### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)

Sidenote on Molecule tests, as a test for setting `nginx_install_epel_release` to false would effectively require current tests to be disabled, and as the default behavior is not altered, no additional tests have been added.