### PR TITLE
Remove deprecation warning for split up NGINX Config/Unit roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 BREAKING CHANGES:
 
-*   Remove the deprecation warning in the README detailing the advent of the [NGINX Core Ansible collection](https://github.com/nginxinc/ansible-collection-nginx) and the subsequent splitting from this role of the [Ansible NGINX Config role](https://github.com/nginxinc/ansible-role-nginx-config) and the [Ansible NGINX Unit role](https://github.com/nginxinc/ansible-role-nginx-unit).
+Remove the deprecation warning in the README detailing the advent of the [NGINX Core Ansible collection](https://github.com/nginxinc/ansible-collection-nginx) and the subsequent splitting from this role of the [Ansible NGINX Config role](https://github.com/nginxinc/ansible-role-nginx-config) and the [Ansible NGINX Unit role](https://github.com/nginxinc/ansible-role-nginx-unit).
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.21.0 (Unreleased)
 
+BREAKING CHANGES:
+
+*   Remove the deprecation warning in the README detailing the advent of the [NGINX Core Ansible collection](https://github.com/nginxinc/ansible-collection-nginx) and the subsequent splitting from this role of the [Ansible NGINX Config role](https://github.com/nginxinc/ansible-role-nginx-config) and the [Ansible NGINX Unit role](https://github.com/nginxinc/ansible-role-nginx-unit).
+
 FEATURES:
 
 *   Add a `nginx_manage_repo` feature flag which allows disabling NGINX repo management by this role.
@@ -19,7 +23,7 @@ ENHANCEMENTS:
 *   Replace Ansible base with Ansible core. Ansible core will be the "core" Ansible release moving forward from Ansible `2.11`.
 *   Update GitHub actions to add a workflow dispatch option.
 *   Replace "yes"/"no" boolean values with "true"/"false" to comply with YAML spec `1.2`.
-*   Update the Ansible `community.general` collection to `3.2.0` and `community.docker` collection to `1.7.0`.
+*   Bump the Ansible `community.general` collection to `3.2.0` and `community.docker` collection to `1.7.0`.
 
 BUG FIXES:
 
@@ -37,6 +41,8 @@ FEATURES:
         version: 3.0.0
       - name: ansible.posix
         version: 1.2.0
+      - name: community.docker  # This collection is only used as part of the Molecule testing suite
+        version: 1.5.0
     ```
 *   Explicitly list Jinja2 `2.11.3` as a requirement, as well as detail the minimum supported version (`2.11.x`).
 *   Add support for Dependabot.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,6 @@ This role installs NGINX Open Source, NGINX Plus, or the NGINX Amplify agent on 
 
 **Note:** This role is still in active development. There may be unidentified issues and the role variables may change as development continues.
 
-**Deprecation Warnings:**
-
-With the advent of Ansible collections and the release of the [NGINX Core Ansible collection](https://github.com/nginxinc/ansible-collection-nginx), the decision has been made to split this role into three smaller roles and reduce the overhead of this role:
-*   The NGINX Ansible role will keep working as is and be used to install and setup NGINX.
-*   **The NGINX configuration functionalities included in this role have been removed as of release 0.19.0.** There now is a separate role to manage and create NGINX configurations available [here](https://github.com/nginxinc/ansible-role-nginx-config). Any new issues or PRs related to configuring NGINX should be submitted in the new NGINX configuration Ansible role repository. New issues or PRs related to configuring NGINX submitted in this repository will not be worked on. This disclaimer will be removed in the upcoming `0.21.0` release at some stage after July 2021.
-*   **The NGINX Unit functionalities included in this role have been removed as of release 0.18.0.** There now is a separate role to install NGINX Unit available [here](https://github.com/nginxinc/ansible-role-nginx-unit). Any new issues or PRs related to NGINX Unit should be submitted in the new NGINX Unit Ansible role repository. New issues or PRs related to NGINX Unit submitted in this repository will not be worked on. This disclaimer will be removed in the upcoming `0.21.0` release at some stage after July 2021.
-
 ## Requirements
 
 ### Ansible


### PR DESCRIPTION
### Proposed changes
Remove the deprecation warning in the README detailing the advent of the [NGINX Core Ansible collection](https://github.com/nginxinc/ansible-collection-nginx) and the subsequent splitting from this role of the [Ansible NGINX Config role](https://github.com/nginxinc/ansible-role-nginx-config) and the [Ansible NGINX Unit role](https://github.com/nginxinc/ansible-role-nginx-unit).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that any relevant Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
