### PR TITLE
Update list of supported platforms for NGINX Plus R25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Support installing NGINX OSS in Amazon Linux.
 
 ENHANCEMENTS:
 
-*   Update the README and Ansible metadata matrix of supported distributions.
-*   Update the Molecule tests to include the newly supported distributions and remove distributions that are no longer supported.
+*   Update the README and Ansible metadata matrix of supported distributions for NGINX OSS and NGINX Plus.
+*   Update the Molecule tests to include the newly supported distributions and remove distributions that are no longer supported for NGINX OSS and NGINX Plus.
 
 ## 0.21.0 (August 11, 2021)
 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,10 @@ Ubuntu:
 
 ```yaml
 Alpine:
-  - 3.10
   - 3.11
   - 3.12
   - 3.13
-Amazon Linux:
-  - 2018.03
+  - 3.14
 Amazon Linux 2:
   - any
 CentOS:
@@ -96,9 +94,10 @@ CentOS:
   - 8
 Debian:
   - buster
+  - bullseye
 FreeBSD:
-  - 11.2+
   - 12.1+
+  - 13
 Oracle Linux:
   - 7.4+
 Red Hat:
@@ -108,10 +107,8 @@ SUSE/SLES:
   - 12
   - 15
 Ubuntu:
-  - xenial
   - bionic
   - focal
-  - groovy
 ```
 
 ### NGINX Amplify Agent

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,15 +8,12 @@ galaxy_info:
 
   license: Apache License, Version 2.0
 
-  min_ansible_version: 2.10
+  min_ansible_version: 2.11
 
   platforms:
     - name: Alpine
       versions:
         - any
-    - name: Amazon
-      versions:
-        - 2018.03
     - name: Amazon Linux 2
       versions:
         - any
@@ -30,12 +27,10 @@ galaxy_info:
         - 8
     - name: FreeBSD
       versions:
-        - 11.4
         - 12.1
         - 13
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
         - hirsute

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -34,7 +34,7 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/sbin/init"
-  - name: amazonlinux
+  - name: amazonlinux-2
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true

--- a/molecule/module/molecule.yml
+++ b/molecule/module/molecule.yml
@@ -34,7 +34,7 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/sbin/init"
-  - name: amazonlinux
+  - name: amazonlinux-2
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -6,13 +6,6 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.10
-    image: alpine:3.10
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
   - name: alpine-3.11
     image: alpine:3.11
     dockerfile: ../common/Dockerfile.j2
@@ -34,7 +27,14 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/sbin/init"
-  - name: amazonlinux
+  - name: alpine-3.14
+    image: alpine:3.14
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: amazonlinux-2
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
@@ -62,8 +62,8 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/sbin/init"
-  - name: ubuntu-xenial
-    image: ubuntu:xenial
+  - name: debian-bullseye
+    image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -34,7 +34,7 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/sbin/init"
-  - name: amazonlinux
+  - name: amazonlinux-2
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true


### PR DESCRIPTION
### Proposed changes

* Update the README and Ansible metadata matrix of supported distributions for NGINX Plus.
* Update the Molecule tests to include the newly supported distributions and remove distributions that are no longer supported for NGINX Plus.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
