### PR TITLE
Add static core modules support to installation from source

### DIFF
--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -92,11 +92,18 @@ nginx_setup_license: true
 # Default is true.
 nginx_remove_license: true
 
-# Install NGINX Modules.
-# You can select any of the modules listed below. Beware of NGINX Plus only modules (these are marked).
-# Format is list with either the module name or a dictionary (see njs for an example).
+# Install NGINX Static Modules.
+# You can select any of the static modules listed on http://nginx.org/en/docs/configure.html.
+# Format is '--with-*' where '*' should be used as static module name in the list below. (see an example below).
+# Default is 'http_ssl_module'. (DO NOT remove it if you need SSL support).
+nginx_static_modules: ['http_ssl_module']
+# nginx_static_modules: ['http_v2_module']  # Example for '--with-http_v2_module'
+
+# Install NGINX Dynamic Modules.
+# You can select any of the dynamic modules listed below. Beware of NGINX Plus only dynamic modules (these are marked).
+# Format is list with either the dynamic module name or a dictionary (see njs for an example).
 # When using a dictionary, the default value for state is present, and for version it's nginx_version if specified.
-# Default is an empty list (no modules are installed).
+# Default is an empty list (no dynamic modules are installed).
 nginx_modules: []
   # - auth-spnego  # NGINX Plus
   # - brotli  # NGINX Plus

--- a/molecule/source/converge.yml
+++ b/molecule/source/converge.yml
@@ -10,6 +10,7 @@
 
         nginx_install_from: source
         nginx_branch: stable
+        nginx_static_modules: ['http_ssl_module']
         nginx_install_source_build_tools: true
         nginx_install_source_pcre: true
         nginx_install_source_openssl: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
           when: nginx_type == "plus"
           tags: nginx_install_plus
 
-        - name: Install NGINX modules
+        - name: Install NGINX dynamic modules
           include_tasks: "{{ role_path }}/tasks/modules/install-modules.yml"
           when:
             - nginx_modules is defined

--- a/tasks/opensource/install-source.yml
+++ b/tasks/opensource/install-source.yml
@@ -322,6 +322,11 @@
         src: "{{ nginx_source.dest }}"
         mode: 0755
 
+    - name: Set static modules
+      set_fact:
+        nginx_install_source_static_modules: "{{ nginx_install_source_static_modules | default('') + ' --with-' + item }}"
+      loop: "{{ nginx_static_modules }}"
+
     - name: Configure NGINX
       command: >-
         ./configure
@@ -332,12 +337,12 @@
         --modules-path=/usr/lib/nginx/modules
         --prefix=/usr
         --pid-path=/var/run/nginx.pid
-        --with-http_ssl_module
         --with-mail=dynamic
         --with-stream
         {{ nginx_install_source_pcre | ternary('', '--with-pcre=../' + pcre_version) }}
         {{ nginx_install_source_zlib | ternary('', '--with-zlib=../' + zlib_version) }}
         {{ nginx_install_source_openssl | ternary('', '--with-openssl=../' + openssl_version) }}
+        {{ nginx_install_source_static_modules | default('') }}
       args:
         chdir: "/tmp/{{ nginx_version }}"
       register: nginx_configure

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -72,12 +72,12 @@ pcre_version: pcre-8.44
 zlib_version: zlib-1.2.11
 openssl_version: openssl-1.1.1g
 
-# Supported NGINX Open Source modules
+# Supported NGINX Open Source dynamic modules
 nginx_modules_list: [
   'geoip', 'image-filter', 'njs', 'perl', 'xslt',
 ]
 
-# Supported NGINX Plus modules
+# Supported NGINX Plus dynamic modules
 nginx_plus_modules_list: [
   'auth-spnego', 'brotli', 'cookie-flag', 'encrypted-session', 'geoip', 'geoip2', 'headers-more', 'image-filter',
   'lua', 'njs', 'opentracing', 'passenger', 'perl', 'prometheus', 'rtmp', 'subs-filter', 'xslt',


### PR DESCRIPTION
### Proposed changes

This enables users to define a list of NGINX static core modules that are configured and built during the build time.
The list is defined using `nginx_static_modules` variable and has a default value of `['http_ssl_module']` to support the default `./configure` command.
The format is '--with-\*' where '\*' should be used as a static module name in the list.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
