### PR TITLE
Remove RHEL/CentOS 6 parameters given they have reached EOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.21.2 (Unreleased)
+
+ENHANCEMENTS:
+
+Remove RHEL/CentOS 6 task specific parameters given those platforms have reached EOL.
+
 ## 0.21.1 (September 29, 2021)
 
 FEATURES:

--- a/tasks/keys/setup-keys.yml
+++ b/tasks/keys/setup-keys.yml
@@ -27,5 +27,4 @@
   rpm_key:
     fingerprint: 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
     key: "{{ keysite }}"
-    validate_certs: "{{ (ansible_facts['distribution_major_version'] is version('6', '==')) | ternary('false', 'true') }}"
   when: ansible_facts['os_family'] in ['RedHat', 'Suse']

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -30,4 +30,4 @@
       or (ansible_facts['distribution'] == "OracleLinux"))
     - not (item.name | default(item) == "geoip2") or not (ansible_facts['os_family'] == "Suse")
     - not (item.name | default(item) == "opentracing")
-      or not ((ansible_facts['os_family'] == "Suse" and ansible_facts['distribution_major_version'] is version('12', '=='))
+      or not (ansible_facts['os_family'] == "Suse" and ansible_facts['distribution_major_version'] is version('12', '=='))

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -31,4 +31,3 @@
     - not (item.name | default(item) == "geoip2") or not (ansible_facts['os_family'] == "Suse")
     - not (item.name | default(item) == "opentracing")
       or not ((ansible_facts['os_family'] == "Suse" and ansible_facts['distribution_major_version'] is version('12', '=='))
-      or (ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] is version('6', '==')))

--- a/tasks/opensource/install-source.yml
+++ b/tasks/opensource/install-source.yml
@@ -130,8 +130,6 @@
         url: "https://ftp.pcre.org/pub/pcre/{{ pcre_version }}.tar.gz"
         dest: "/tmp/{{ pcre_version }}.tar.gz"
         mode: 0600
-        validate_certs: "{{ (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] is version('6', '=='))
-                        | ternary('false', 'true') }}"
       register: pcre_source
 
     - name: Unpack PCRE dependency
@@ -190,8 +188,6 @@
         url: "https://zlib.net/{{ zlib_version }}.tar.gz"
         dest: "/tmp/{{ zlib_version }}.tar.gz"
         mode: 0600
-        validate_certs: "{{ (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] is version('6', '=='))
-                        | ternary('false', 'true') }}"
       register: zlib_source
 
     - name: Unpack ZLib dependency
@@ -250,8 +246,6 @@
         url: "https://www.openssl.org/source/{{ openssl_version }}.tar.gz"
         dest: "/tmp/{{ openssl_version }}.tar.gz"
         mode: 0600
-        validate_certs: "{{ (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] is version('6', '=='))
-                        | ternary('false', 'true') }}"
       register: openssl_source
 
     - name: Unpack OpenSSL dependency
@@ -285,8 +279,6 @@
       uri:
         url: https://version.nginx.com/nginx/{{ nginx_branch }}
         return_content: true
-        validate_certs: "{{ (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] is version('6', '=='))
-                        | ternary('false', 'true') }}"
       check_mode: false
       register: nginx_versions
 
@@ -311,8 +303,6 @@
         url: "https://nginx.org/download/{{ nginx_version }}.tar.gz"
         dest: "/tmp/{{ nginx_version }}.tar.gz"
         mode: 0600
-        validate_certs: "{{ (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] is version('6', '=='))
-                        | ternary('false', 'true') }}"
       register: nginx_source
 
     - name: Unpack NGINX


### PR DESCRIPTION
### Proposed changes

Remove RHEL/CentOS 6 task specific parameters given those platforms have reached EOL.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
