### PR TITLE
Always update NGINX dependencies to the latest available version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ENHANCEMENTS:
 
-Change Ansible Lint exceptions from using an ID identifier to a text identifier.
+* Change Ansible Lint exceptions from using an ID identifier to a text identifier.
+* Move non NGINX specific dependencies from the role into the Molecule Dockerfile.
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.21.2 (Unreleased)
+
+ENHANCEMENTS:
+
+Change Ansible Lint exceptions from using an ID identifier to a text identifier.
+
+BUG FIXES:
+
+Always update NGINX dependencies to the latest available version to avoid outdated dependency issues (e.g. outdated CA certificates).
+
 ## 0.21.1 (September 29, 2021)
 
 FEATURES:

--- a/molecule/common/Dockerfile.j2
+++ b/molecule/common/Dockerfile.j2
@@ -34,7 +34,7 @@ RUN \
     && zypper clean -a; \
   elif [ $(command -v apk) ]; then \
     apk update \
-    && apk add --no-cache bash curl openrc pcre python3 sudo vim; \
+    && apk add --no-cache bash coreutils curl openrc openssl pcre python3 sudo vim; \
     echo 'rc_provide="loopback net"' >> /etc/rc.conf; \
   elif [ $(command -v xbps-install) ]; then \
     xbps-install -Syu \

--- a/molecule/common/Dockerfile.j2
+++ b/molecule/common/Dockerfile.j2
@@ -17,7 +17,7 @@ ENV {{ var }} {{ value }}
 RUN \
   if [ $(command -v apt-get) ]; then \
     apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y aptitude bash ca-certificates curl iproute2 python3 python3-apt procps sudo systemd systemd-sysv vim \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y aptitude bash curl dirmngr iproute2 python3 python3-apt procps sudo systemd systemd-sysv vim \
     && apt-get clean; \
   elif [ $(command -v dnf) ]; then \
     dnf makecache \
@@ -34,10 +34,10 @@ RUN \
     && zypper clean -a; \
   elif [ $(command -v apk) ]; then \
     apk update \
-    && apk add --no-cache bash ca-certificates curl openrc python3 sudo vim; \
+    && apk add --no-cache bash curl openrc pcre python3 sudo vim; \
     echo 'rc_provide="loopback net"' >> /etc/rc.conf; \
   elif [ $(command -v xbps-install) ]; then \
     xbps-install -Syu \
-    && xbps-install -y bash ca-certificates iproute2 python3 sudo vim \
+    && xbps-install -y bash iproute2 python3 sudo vim \
     && xbps-remove -O; \
   fi

--- a/molecule/common/Dockerfile.j2
+++ b/molecule/common/Dockerfile.j2
@@ -34,7 +34,7 @@ RUN \
     && zypper clean -a; \
   elif [ $(command -v apk) ]; then \
     apk update \
-    && apk add --no-cache bash coreutils curl openrc openssl pcre python3 sudo vim; \
+    && apk add --no-cache bash curl openrc python3 sudo vim; \
     echo 'rc_provide="loopback net"' >> /etc/rc.conf; \
   elif [ $(command -v xbps-install) ]; then \
     xbps-install -Syu \

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -17,7 +17,7 @@
     - name: Enable NGINX @CentOS-AppStream dnf modules
       shell:
       args:
-        cmd: dnf module info nginx | grep -q 'Stream.*\[e\]' && echo -n ENABLED || dnf module enable -y nginx  # noqa 204 303
+        cmd: dnf module info nginx | grep -q 'Stream.*\[e\]' && echo -n ENABLED || dnf module enable -y nginx  # noqa command-instead-of-module
       register: dnf_module_enable
       changed_when: dnf_module_enable.stdout != 'ENABLED'
       when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] is version('8', '==')

--- a/tasks/prerequisites/install-dependencies.yml
+++ b/tasks/prerequisites/install-dependencies.yml
@@ -3,22 +3,28 @@
   apk:
     name: "{{ nginx_alpine_dependencies }}"
     update_cache: true
+    state: latest  # noqa package-latest
   when: ansible_facts['os_family'] == "Alpine"
 
 - name: (Debian/Ubuntu) Install dependencies
   apt:
     name: "{{ nginx_debian_dependencies }}"
     update_cache: true
+    state: latest  # noqa package-latest
   when: ansible_facts['os_family'] == "Debian"
 
 - name: (Amazon Linux/CentOS/Oracle Linux/RHEL) Install dependencies
   yum:
     name: "{{ nginx_redhat_dependencies }}"
+    update_cache: true
+    state: latest  # noqa package-latest
   when: ansible_facts['os_family'] == "RedHat"
 
 - name: (SLES) Install dependencies
   zypper:
     name: "{{ nginx_sles_dependencies }}"
+    update_cache: true
+    state: latest  # noqa package-latest
   when: ansible_facts['os_family'] == "Suse"
 
 - name: (FreeBSD) Install dependencies

--- a/tasks/prerequisites/install-dependencies.yml
+++ b/tasks/prerequisites/install-dependencies.yml
@@ -32,12 +32,14 @@
     - name: (FreeBSD) Install dependencies using package(s)
       pkgng:
         name: "{{ nginx_freebsd_dependencies }}"
+        state: latest  # noqa package-latest
       when: nginx_bsd_install_packages | bool
 
     - name: (FreeBSD) Install dependencies using port(s)
       portinstall:
         name: "{{ item }}"
         use_packages: "{{ nginx_bsd_portinstall_use_packages | default(omit) }}"
+        state: latest  # noqa package-latest
       loop: "{{ nginx_freebsd_dependencies }}"
       when: not nginx_bsd_install_packages | bool
   when: ansible_facts['distribution'] == "FreeBSD"

--- a/tasks/prerequisites/setup-selinux.yml
+++ b/tasks/prerequisites/setup-selinux.yml
@@ -86,7 +86,7 @@
   changed_when: false
 
 - name: Import SELinux NGINX Plus module
-  command: "semodule -i {{ nginx_selinux_tempdir }}/nginx-plus-module.pp"  # noqa 503
+  command: "semodule -i {{ nginx_selinux_tempdir }}/nginx-plus-module.pp"  # noqa no-handler
   changed_when: false
   when: nginx_selinux_module.changed | bool
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -44,17 +44,17 @@ nginx_plus_default_repository_suse: "https://pkgs.nginx.com/plus/sles/{{ ansible
 
 # Alpine dependencies
 nginx_alpine_dependencies: [
-  'coreutils', 'openssl', 'pcre',
+  'ca-certificates',
 ]
 
 # Debian dependencies
 nginx_debian_dependencies: [
-  'apt-transport-https', 'ca-certificates', 'dirmngr',
+  'apt-transport-https', 'ca-certificates',
 ]
 
 # Red Hat dependencies
 nginx_redhat_dependencies: [
-  'ca-certificates', 'openssl', 'yum-utils',
+  'ca-certificates',
 ]
 
 # SLES dependencies

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -44,7 +44,7 @@ nginx_plus_default_repository_suse: "https://pkgs.nginx.com/plus/sles/{{ ansible
 
 # Alpine dependencies
 nginx_alpine_dependencies: [
-  'ca-certificates',
+  'ca-certificates', 'coreutils', 'openssl', 'pcre',
 ]
 
 # Debian dependencies


### PR DESCRIPTION
### Proposed changes

ENHANCEMENTS:

* Change Ansible Lint exceptions from using an ID identifier to a text identifier.
* Move non NGINX specific dependencies from the role into the Molecule Dockerfile.

BUG FIXES:

Always update NGINX dependencies to the latest available version to avoid outdated dependency issues (e.g. outdated CA certificates).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
