### PR TITLE
Run Check NGINX handler in the correct directory in BSD systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-Always update NGINX dependencies to the latest available version to avoid outdated dependency issues (e.g. outdated CA certificates).
+* Always update NGINX dependencies to the latest available version to avoid outdated dependency issues (e.g. outdated CA certificates).
+* The Check NGINX handler should now be run in the correct directory in BSD systems.
 
 ## 0.21.1 (September 29, 2021)
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,7 +16,7 @@
 - name: (Handler) Check NGINX
   command: nginx -t
   args:
-    chdir: /etc/nginx/
+    chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
   register: config_check
   ignore_errors: true
   check_mode: false


### PR DESCRIPTION
### Proposed changes

The Check NGINX handler should now be run in the correct directory in BSD systems.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
