### PR TITLE
Pin Alpine and Debian OSS repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.21.4 (Unreleased)
 
+FEATURES:
+
+Pin repository data when installing NGINX OSS on Alpine and Debian distributions.
+
+ENHANCEMENTS:
+
+Add Alpine Linux 3.15 to list of tested and supported platforms.
+
 BUG FIXES:
 
 When building NGINX from source, the original source FTP repository `ftp.pcre.org` is not available anymore, according to <http://pcre.org>. The FTP repository has been updated to use `ftp.exim.org` instead.

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ The NGINX Ansible role supports all platforms supported by [NGINX Open Source](h
 
 ```yaml
 Alpine:
-  - 3.11
   - 3.12
   - 3.13
   - 3.14
+  - 3.15
 Amazon Linux:
   - 2
 CentOS:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,15 +4,15 @@
   pre_tasks:
     - name: Set repo if Alpine
       set_fact:
-        version: "=1.21.1-r1"
+        version: "=1.21.4-r1"
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       set_fact:
-        version: "=1.21.1-1~{{ ansible_facts['distribution_release'] }}"
+        version: "=1.21.4-1~{{ ansible_facts['distribution_release'] }}"
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       set_fact:
-        version: "-1.21.1-1.{{ (ansible_facts['distribution']=='Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
+        version: "-1.21.4-1.{{ (ansible_facts['distribution']=='Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
       when: ansible_facts['os_family'] == "RedHat"
     - name: Enable NGINX @CentOS-AppStream dnf modules
       shell:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,13 +6,6 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.11
-    image: alpine:3.11
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
   - name: alpine-3.12
     image: alpine:3.12
     dockerfile: ../common/Dockerfile.j2
@@ -29,6 +22,13 @@ platforms:
     command: "/sbin/init"
   - name: alpine-3.14
     image: alpine:3.14
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.15
+    image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/molecule/module/molecule.yml
+++ b/molecule/module/molecule.yml
@@ -6,13 +6,6 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.11
-    image: alpine:3.11
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
   - name: alpine-3.12
     image: alpine:3.12
     dockerfile: ../common/Dockerfile.j2
@@ -29,6 +22,13 @@ platforms:
     command: "/sbin/init"
   - name: alpine-3.14
     image: alpine:3.14
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.15
+    image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -6,13 +6,6 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.11
-    image: alpine:3.11
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
   - name: alpine-3.12
     image: alpine:3.12
     dockerfile: ../common/Dockerfile.j2
@@ -29,6 +22,13 @@ platforms:
     command: "/sbin/init"
   - name: alpine-3.14
     image: alpine:3.14
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.15
+    image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/tasks/keys/setup-keys.yml
+++ b/tasks/keys/setup-keys.yml
@@ -20,6 +20,7 @@
 - name: (Debian/Ubuntu) Add NGINX signing key
   apt_key:
     id: 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+    keyring: /usr/share/keyrings/nginx-archive-keyring.gpg
     url: "{{ keysite }}"
   when: ansible_facts['os_family'] == "Debian"
 

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -10,7 +10,7 @@
 - name: Install NGINX modules
   package:
     name: "nginx-{{ (nginx_type == 'plus') | ternary('plus-', '') }}module-{{ item.name | default(item) }}\
-          {{ item.version | default(nginx_version) | default('') }}"
+          {{ item.version | default(nginx_version) | default('') }}{{ (nginx_repository is not defined and ansible_facts['os_family'] == 'Alpine') | ternary('@nginx', '') }}"
     state: "{{ item.state | default('present') }}"
   loop: "{{ nginx_modules }}"
   when:

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -10,7 +10,7 @@
 - name: Install NGINX modules
   package:
     name: "nginx-{{ (nginx_type == 'plus') | ternary('plus-', '') }}module-{{ item.name | default(item) }}\
-          {{ item.version | default(nginx_version) | default('') }}{{ (nginx_repository is not defined and ansible_facts['os_family'] == 'Alpine') | ternary('@nginx', '') }}"
+          {{ item.version | default(nginx_version) | default('') }}{{ (nginx_repository is not defined and ansible_facts['os_family'] == 'Alpine' and nginx_type != 'plus') | ternary('@nginx', '') }}"
     state: "{{ item.state | default('present') }}"
   loop: "{{ nginx_modules }}"
   when:

--- a/tasks/opensource/install-alpine.yml
+++ b/tasks/opensource/install-alpine.yml
@@ -8,8 +8,7 @@
 
 - name: (Alpine Linux) Install NGINX
   apk:
-    name: "nginx{{ nginx_version | default('') }}"
-    repository: "{{ nginx_repository | default(nginx_default_repository_alpine) }}"
+    name: "nginx{{ nginx_repository is not defined | ternary('@nginx', '') }}{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     update_cache: true
   ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/opensource/install-alpine.yml
+++ b/tasks/opensource/install-alpine.yml
@@ -8,7 +8,8 @@
 
 - name: (Alpine Linux) Install NGINX
   apk:
-    name: "nginx{{ nginx_repository is not defined | ternary('@nginx', '') }}{{ nginx_version | default('') }}"
+    name: "nginx{{ nginx_version | default('') }}"
+    repository: "{{ nginx_repository | default(nginx_default_repository_alpine) }}"
     state: "{{ nginx_state }}"
     update_cache: true
   ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/opensource/install-debian.yml
+++ b/tasks/opensource/install-debian.yml
@@ -8,6 +8,18 @@
   loop: "{{ nginx_repository | default(nginx_default_repository_debian) }}"
   when: nginx_manage_repo | bool
 
+- name: (Debian/Ubuntu) Pin NGINX repository
+  blockinfile:
+    path: /etc/apt/preferences.d/99nginx
+    create: true
+    block: |
+      Package: *
+      Pin: origin nginx.org
+      Pin: release o=nginx
+      Pin-Priority: 900
+    mode: 0644
+  when: nginx_repository is not defined
+
 - name: (Debian/Ubuntu) Install NGINX
   apt:
     name: "nginx{{ nginx_version | default('') }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,13 +17,13 @@ nginx_default_signing_key_rsa_pub: https://nginx.org/keys/nginx_signing.rsa.pub
 nginx_default_signing_key_pgp: https://nginx.org/keys/nginx_signing.key
 
 # Default NGINX Open Source repositories
-nginx_default_repository_alpine: "https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}\
+nginx_default_repository_alpine: "@nginx http://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}\
                                   alpine/v{{ ansible_facts['distribution_version'] | regex_search('^[0-9]+\\.[0-9]+') }}/main"
 nginx_default_repository_amazon: "https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}/amzn2/$releasever/$basearch"
 nginx_default_repository_debian:
-  - "deb [arch={{ (ansible_facts['architecture'] == 'aarch64') | ternary('arm64', 'amd64') }}] https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}\
+  - "deb [arch={{ (ansible_facts['architecture'] == 'aarch64') | ternary('arm64', 'amd64') }} signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}\
     {{ ansible_facts['distribution'] | lower }}/ {{ ansible_facts['distribution_release'] }} nginx"
-  - "deb-src https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}\
+  - "deb-src [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}\
     {{ ansible_facts['distribution'] | lower }}/ {{ ansible_facts['distribution_release'] }} nginx"
 nginx_default_repository_redhat: "https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}\
                                   {{ (ansible_facts['distribution'] == 'CentOS') | ternary('centos', 'rhel') }}/\
@@ -34,7 +34,7 @@ nginx_default_repository_suse: "https://nginx.org/packages/{{ (nginx_branch == '
 # Default NGINX Plus repositories
 nginx_plus_default_repository_alpine: "https://pkgs.nginx.com/plus/alpine/v{{ ansible_facts['distribution_version'] | regex_search('^[0-9]+\\.[0-9]+') }}/main"
 nginx_plus_default_repository_amazon: "https://pkgs.nginx.com/plus/amzn{{ (ansible_facts['distribution_major_version'] is version('2', '==')) | ternary('2', '') }}/$releasever/$basearch"
-nginx_plus_default_repository_debian: "deb [arch={{ (ansible_facts['architecture'] == 'aarch64') | ternary('arm64', 'amd64') }}] https://pkgs.nginx.com/plus/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] }} nginx-plus"
+nginx_plus_default_repository_debian: "deb [arch={{ (ansible_facts['architecture'] == 'aarch64') | ternary('arm64', 'amd64') }} signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] }} nginx-plus"
 nginx_plus_default_repository_freebsd: "https://pkgs.nginx.com/plus/freebsd/${ABI}/latest"
 nginx_plus_default_repository_redhat: "https://pkgs.nginx.com/plus/{{ (ansible_facts['distribution'] == 'CentOS') | ternary('centos', 'rhel') }}/\
                                       {{ (ansible_facts['distribution_version'] is version('7.4', '>=')


### PR DESCRIPTION
### Proposed changes

FEATURES:

Pin repository data when installing NGINX OSS on Alpine and Debian distributions.

ENHANCEMENTS:

Add Alpine Linux 3.15 to list of tested and supported platforms.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
