### PR TITLE
Improve uninstalling NGINX capabilities

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -23,6 +23,7 @@ jobs:
           - module
           - plus
           - source
+          - uninstall
     steps:
       - name: Check out the codebase
         if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -25,6 +25,7 @@ jobs:
           - source
           - uninstall
           - uninstall_plus
+          - upgrade
     steps:
       - name: Check out the codebase
         if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -24,6 +24,7 @@ jobs:
           - plus
           - source
           - uninstall
+          - uninstall_plus
     steps:
       - name: Check out the codebase
         if: "!(contains(matrix.scenario, 'plus') && github.event.pull_request.head.repo.full_name != github.repository)"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ Thumbs.db
 # Python specific #
 ###################
 __pycache__
+
+# Logs #
+########
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Add Alpine Linux 3.15 to list of tested and supported platforms.
 
 BUG FIXES:
 
-When building NGINX from source, the original source FTP repository `ftp.pcre.org` is not available anymore, according to <http://pcre.org>. The FTP repository has been updated to use `ftp.exim.org` instead.
+* When building NGINX from source, the original source FTP repository `ftp.pcre.org` is not available anymore, according to <http://pcre.org>. The FTP repository has been updated to use `ftp.exim.org` instead.
+* Uninstalling NGINX should now work correctly under most scenarios.
 
 ## 0.21.3 (October 25, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 BREAKING CHANGES:
 
-* The `nginx_state` variable has been replaced with `nginx_setup` and instead of using `present`, `absent`, `latest` you should now use `install`, `uninstall` and `update`.
+* The `nginx_state` variable has been replaced with `nginx_setup` and instead of using `present`, `absent`, `latest` you should now use `install`, `uninstall` and `upgrade`.
 * `nginx_install` variable is no more. Use `nginx_enable` instead.
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 0.21.4 (Unreleased)
+## 0.22.0 (Unreleased)
+
+BREAKING CHANGES:
+
+* The `nginx_state` variable has been replaced with `nginx_setup` and instead of using `present`, `absent`, `latest` you should now use `install`, `uninstall` and `update`.
+* `nginx_install` variable is no more. Use `nginx_enable` instead.
 
 FEATURES:
 
@@ -217,7 +222,7 @@ FEATURES:
 * A new variable has been introduced:
   * `nginx_setup_license` -- Determine whether you want to use this role to upload your NGINX license to your target host.
 * The role will now fail automatically if you try to deploy NGINX from an official repository in an unsupported distribution. You can find a list of supported distributions for NGINX and NGINX Plus in [`vars/main.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/vars/main.yml)
-* Three new tags have been introduced -- `nginx_setup_license`, `nginx_install` and `nginx_check_support`.
+* Three new tags have been introduced -- `nginx_setup_license`, `nginx_enable` and `nginx_check_support`.
 * Add Alpine 3.12 to the list of supported platforms.
 * Remove Alpine 3.8 from the list of supported platforms.
 * Add NGINX Plus tests to TravisCI
@@ -301,7 +306,7 @@ FEATURES:
 * Add support to configure logrotate.
 * Add support for Ubuntu Focal.
 * Add support to configure SELinux.
-* Two new variables have been introduced -- `nginx_install` and `nginx_configure` -- to let you choose whether you want to install NGINX, configure NGINX, or both.
+* Two new variables have been introduced -- `nginx_enable` and `nginx_configure` -- to let you choose whether you want to install NGINX, configure NGINX, or both.
 
 ENHANCEMENTS:
 

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -18,11 +18,12 @@ nginx_type: opensource
 # For NGINX Plus and modules you'll need a wilcard like below (which installs plus-20 and modules)
 # nginx_version: "-20*"
 
-# Specify whether you want to maintain your version of NGINX, upgrade to the latest version, or remove NGINX.
-# Can be used with `nginx_version` to fine tune con
 # Start NGINX service.
 # Default is true.
-nginx_start: truetrol on which version of NGINX is installed/used on each playbook execution.
+nginx_start: true
+
+# Specify whether you want to maintain your version of NGINX, upgrade to the latest version, or remove NGINX.
+# Can be used with `nginx_version` to fine tune control which version of NGINX is installed/used on each playbook execution.
 # Using 'install' will install the latest version (or 'nginx_version') of NGINX on a fresh install.
 # Using 'update' will upgrade NGINX to the latest version (that matches your 'nginx_version') of NGINX on every playbook execution.
 # Using 'uninstall' will remove NGINX from your system.

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -1,16 +1,8 @@
 ---
-# Enable NGINX options -- `nginx_install` and `nginx_configure`.
-# Default is true.
-nginx_enable: true
-
-# Install NGINX and NGINX modules.
+# Enable NGINX and NGINX modules.
 # Variables for these options can be found below.
 # Default is true.
-nginx_install: true
-
-# Start NGINX service.
-# Default is true.
-nginx_start: true
+nginx_enable: true
 
 # Print NGINX configuration file to terminal after executing playbook.
 nginx_debug_output: false
@@ -27,12 +19,15 @@ nginx_type: opensource
 # nginx_version: "-20*"
 
 # Specify whether you want to maintain your version of NGINX, upgrade to the latest version, or remove NGINX.
-# Can be used with `nginx_version` to fine tune control on which version of NGINX is installed/used on each playbook execution.
-# Using 'present' will install the latest version (or 'nginx_version') of NGINX on a fresh install.
-# Using 'latest' will upgrade NGINX to the latest version (that matches your 'nginx_version') of NGINX on every playbook execution.
-# Using 'absent' will remove NGINX from your system.
-# Default is present.
-nginx_state: present
+# Can be used with `nginx_version` to fine tune con
+# Start NGINX service.
+# Default is true.
+nginx_start: truetrol on which version of NGINX is installed/used on each playbook execution.
+# Using 'install' will install the latest version (or 'nginx_version') of NGINX on a fresh install.
+# Using 'update' will upgrade NGINX to the latest version (that matches your 'nginx_version') of NGINX on every playbook execution.
+# Using 'uninstall' will remove NGINX from your system.
+# Default is install.
+nginx_setup: install
 
 # Specify whether or not you want to manage the NGINX repositories.
 # Using 'true' will manage NGINX repositories.

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -25,7 +25,7 @@ nginx_start: true
 # Specify whether you want to maintain your version of NGINX, upgrade to the latest version, or remove NGINX.
 # Can be used with `nginx_version` to fine tune control which version of NGINX is installed/used on each playbook execution.
 # Using 'install' will install the latest version (or 'nginx_version') of NGINX on a fresh install.
-# Using 'upgrade' will upgrade NGINX to the latest version (that matches your 'nginx_version') of NGINX on every playbook execution.
+# Using 'upgrade' will upgrade NGINX to the latest version (that matches your 'nginx_version') of NGINX on every playbook execution. Does not work on Alpine Linux.
 # Using 'uninstall' will remove NGINX from your system.
 # Default is install.
 nginx_setup: install

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -25,7 +25,7 @@ nginx_start: true
 # Specify whether you want to maintain your version of NGINX, upgrade to the latest version, or remove NGINX.
 # Can be used with `nginx_version` to fine tune control which version of NGINX is installed/used on each playbook execution.
 # Using 'install' will install the latest version (or 'nginx_version') of NGINX on a fresh install.
-# Using 'update' will upgrade NGINX to the latest version (that matches your 'nginx_version') of NGINX on every playbook execution.
+# Using 'upgrade' will upgrade NGINX to the latest version (that matches your 'nginx_version') of NGINX on every playbook execution.
 # Using 'uninstall' will remove NGINX from your system.
 # Default is install.
 nginx_setup: install

--- a/defaults/main/selinux.yml
+++ b/defaults/main/selinux.yml
@@ -1,12 +1,15 @@
 ---
 # Set SELinux enforcing for NGINX (CentOS/Red Hat only) - you may need to open ports on your own
 nginx_selinux: false
+
 # Enable enforcing mode if true.  Permissive if false (audit only, no enforcing) globally (only works with nginx_selinux: true)
+
 nginx_selinux_enforcing: true
 # List of TCP ports to add to http_port_t type (80 and 443 have this type already)
 # nginx_selinux_tcp_ports:
 #   - 80
 #   - 443
+
 # List of UDP ports to add to http_port_t type
 # nginx_selinux_udp_ports:
 #   - 80

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,6 +10,7 @@
     enabled: true
   when:
     - nginx_start | bool
+    - nginx_state != "absent"
     - not ansible_check_mode | bool
   listen: (Handler) Run NGINX
 
@@ -21,6 +22,7 @@
   ignore_errors: true
   check_mode: false
   changed_when: false
+  when: nginx_state != "absent"
   listen: (Handler) Run NGINX
 
 - name: (Handler) Print NGINX error if syntax check fails
@@ -30,6 +32,7 @@
   when:
     - config_check.stderr_lines is defined
     - config_check.rc != 0
+    - nginx_state != "absent"
   listen: (Handler) Run NGINX
 
 - name: (Handler) Start NGINX Amplify agent

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -30,4 +30,4 @@
         chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
       changed_when: false
       register: version
-      failed_when: version is not search('1.21.3')
+      failed_when: version is not search('1.21.4')

--- a/molecule/uninstall/converge.yml
+++ b/molecule/uninstall/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Uninstall NGINX
+      include_role:
+        name: ansible-role-nginx
+      vars:
+        nginx_state: absent

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -1,0 +1,91 @@
+---
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint --force-color
+platforms:
+  - name: alpine-3.11
+    image: alpine:3.11
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.12
+    image: alpine:3.12
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.13
+    image: alpine:3.13
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.14
+    image: alpine:3.14
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: amazonlinux-2
+    image: amazonlinux:2
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+  - name: centos-7
+    image: centos:7
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+  - name: centos-8
+    image: centos:8
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+  - name: debian-buster
+    image: debian:buster-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: debian-bullseye
+    image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: ubuntu-bionic
+    image: ubuntu:bionic
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: ubuntu-focal
+    image: ubuntu:focal
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml

--- a/molecule/uninstall/prepare.yml
+++ b/molecule/uninstall/prepare.yml
@@ -1,0 +1,7 @@
+---
+- name: Install NGINX
+  hosts: all
+  tasks:
+    - name: Install NGINX
+      include_role:
+        name: ansible-role-nginx

--- a/molecule/uninstall/verify.yml
+++ b/molecule/uninstall/verify.yml
@@ -1,0 +1,11 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check if NGINX is installed
+      package:
+        name: nginx
+        state: absent
+      check_mode: true
+      register: install
+      failed_when: (install is changed) or (install is failed)

--- a/molecule/uninstall_plus/converge.yml
+++ b/molecule/uninstall_plus/converge.yml
@@ -7,3 +7,5 @@
         name: ansible-role-nginx
       vars:
         nginx_setup: uninstall
+        nginx_type: plus
+        nginx_setup_license: false

--- a/molecule/uninstall_plus/molecule.yml
+++ b/molecule/uninstall_plus/molecule.yml
@@ -6,6 +6,13 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
+  - name: alpine-3.11
+    image: alpine:3.11
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
   - name: alpine-3.12
     image: alpine:3.12
     dockerfile: ../common/Dockerfile.j2
@@ -22,13 +29,6 @@ platforms:
     command: "/sbin/init"
   - name: alpine-3.14
     image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
-  - name: alpine-3.15
-    image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/molecule/uninstall_plus/prepare.yml
+++ b/molecule/uninstall_plus/prepare.yml
@@ -1,6 +1,7 @@
 ---
-- name: Install NGINX
-  hosts: all
+- name: Prepare
+  hosts: localhost
+  gather_facts: false
   tasks:
     - name: Create ephemeral license certificate file from b64 decoded env var
       copy:
@@ -16,12 +17,11 @@
         force: false
         mode: 0444
 
-    - name: Install NGINX
-      include_role:
-        name: ansible-role-nginx
-      vars:
-        nginx_type: plus
-        nginx_license:
-          certificate: license/nginx-repo.crt
-          key: license/nginx-repo.key
-      # nginx_remove_license: false
+- name: Install NGINX
+  include_role:
+    name: ansible-role-nginx
+  vars:
+    nginx_type: plus
+    nginx_license:
+      certificate: license/nginx-repo.crt
+      key: license/nginx-repo.key

--- a/molecule/uninstall_plus/prepare.yml
+++ b/molecule/uninstall_plus/prepare.yml
@@ -2,6 +2,20 @@
 - name: Install NGINX
   hosts: all
   tasks:
+    - name: Create ephemeral license certificate file from b64 decoded env var
+      copy:
+        content: "{{ lookup('env','NGINX_CRT') | b64decode }}"
+        dest: ../../files/license/nginx-repo.crt
+        force: false
+        mode: 0444
+
+    - name: Create ephemeral license key file from b64 decoded env var
+      copy:
+        content: "{{ lookup('env','NGINX_KEY') | b64decode }}"
+        dest: ../../files/license/nginx-repo.key
+        force: false
+        mode: 0444
+
     - name: Install NGINX
       include_role:
         name: ansible-role-nginx

--- a/molecule/uninstall_plus/prepare.yml
+++ b/molecule/uninstall_plus/prepare.yml
@@ -1,0 +1,13 @@
+---
+- name: Install NGINX
+  hosts: all
+  tasks:
+    - name: Install NGINX
+      include_role:
+        name: ansible-role-nginx
+      vars:
+        nginx_type: plus
+        nginx_license:
+          certificate: license/nginx-repo.crt
+          key: license/nginx-repo.key
+      # nginx_remove_license: false

--- a/molecule/uninstall_plus/prepare.yml
+++ b/molecule/uninstall_plus/prepare.yml
@@ -1,5 +1,5 @@
 ---
-- name: Prepare
+- name: Prepare license
   hosts: localhost
   gather_facts: false
   tasks:
@@ -17,7 +17,7 @@
         force: false
         mode: 0444
 
-- name: Install NGINX
+- name: Prepare NGINX
   hosts: all
   tasks:
     - name: Install NGINX

--- a/molecule/uninstall_plus/prepare.yml
+++ b/molecule/uninstall_plus/prepare.yml
@@ -18,10 +18,13 @@
         mode: 0444
 
 - name: Install NGINX
-  include_role:
-    name: ansible-role-nginx
-  vars:
-    nginx_type: plus
-    nginx_license:
-      certificate: license/nginx-repo.crt
-      key: license/nginx-repo.key
+  hosts: all
+  tasks:
+    - name: Install NGINX
+      include_role:
+        name: ansible-role-nginx
+      vars:
+        nginx_type: plus
+        nginx_license:
+          certificate: license/nginx-repo.crt
+          key: license/nginx-repo.key

--- a/molecule/uninstall_plus/verify.yml
+++ b/molecule/uninstall_plus/verify.yml
@@ -1,0 +1,11 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check if NGINX is installed
+      package:
+        name: nginx-plus
+        state: absent
+      check_mode: true
+      register: install
+      failed_when: (install is changed) or (install is failed)

--- a/molecule/upgrade/converge.yml
+++ b/molecule/upgrade/converge.yml
@@ -1,7 +1,9 @@
 ---
-- name: Prepare
+- name: Converge
   hosts: all
   tasks:
     - name: Install NGINX
       include_role:
         name: ansible-role-nginx
+      vars:
+        nginx_setup: upgrade

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -1,0 +1,62 @@
+---
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint --force-color
+platforms:
+  - name: amazonlinux-2
+    image: amazonlinux:2
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+  - name: centos-7
+    image: centos:7
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+  - name: centos-8
+    image: centos:8
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+  - name: debian-buster
+    image: debian:buster-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: debian-bullseye
+    image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: ubuntu-bionic
+    image: ubuntu:bionic
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: ubuntu-focal
+    image: ubuntu:focal
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml

--- a/molecule/upgrade/prepare.yml
+++ b/molecule/upgrade/prepare.yml
@@ -1,18 +1,18 @@
 ---
-- name: Converge
+- name: Prepare
   hosts: all
   pre_tasks:
     - name: Set repo if Alpine
       set_fact:
-        version: "=1.21.4-r1"
+        version: "=1.21.3-r1"
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       set_fact:
-        version: "=1.21.4-1~{{ ansible_facts['distribution_release'] }}"
+        version: "=1.21.3-1~{{ ansible_facts['distribution_release'] }}"
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       set_fact:
-        version: "-1.21.4-1.{{ (ansible_facts['distribution']=='Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
+        version: "-1.21.3-1.{{ (ansible_facts['distribution']=='Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
       when: ansible_facts['os_family'] == "RedHat"
     - name: Enable NGINX @CentOS-AppStream dnf modules
       shell:
@@ -26,21 +26,4 @@
       include_role:
         name: ansible-role-nginx
       vars:
-        nginx_debug_output: true
-        nginx_selinux: true
-        nginx_selinux_tcp_ports:
-          - 80
-          - 443
         nginx_version: "{{ version }}"
-        nginx_logrotate_conf_enable: true
-        nginx_logrotate_conf:
-          paths:
-            - /var/log/nginx/*.log
-          options:
-            - daily
-            - missingok
-            - rotate 14
-            - compress
-            - delaycompress
-            - notifempty
-            - sharedscripts

--- a/molecule/upgrade/verify.yml
+++ b/molecule/upgrade/verify.yml
@@ -24,10 +24,10 @@
         url: http://localhost
         status_code: 200
 
-    - name: Verify correct version of NGINX has been installed
+    - name: Verify NGINX has been upgraded
       command: nginx -v
       args:
         chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
       changed_when: false
       register: version
-      failed_when: version is not search('1.21.3')
+      failed_when: version is not search('1.21.4')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,78 +6,88 @@
     success_msg: "Your OS, {{ ansible_facts['distribution'] }} is supported by NGINX {{ (nginx_type=='plus') | ternary('Plus', 'Open Source') }}"
     fail_msg: "Your OS, {{ ansible_facts['distribution'] }} is not supported by NGINX {{ (nginx_type=='plus') | ternary('Plus', 'Open Source') }}"
   when:
-    - nginx_install | bool
+    - nginx_enable | bool
     - (nginx_install_from == "nginx_repository" or nginx_type == "plus")
+  ignore_errors: true  # noqa ignore-errors
+  tags: nginx_check_support
+
+- name: Check that NGINX setup is an allowed value
+  assert:
+    that: nginx_setup in nginx_setup_vars
+    fail_msg: The value {{ nginx_setup }} you used for `nginx_setup` is not allowed. Try one of {{ nginx_setup_vars | join(, ) }}.
+  when: nginx_enable | bool
   ignore_errors: true  # noqa ignore-errors
   tags: nginx_check_support
 
 - name: Set up prerequisites
   include_tasks: "{{ role_path }}/tasks/prerequisites/prerequisites.yml"
+  when: nginx_state != "absent"
   tags: nginx_prerequisites
 
 - name: Set up signing keys
   include_tasks: "{{ role_path }}/tasks/keys/setup-keys.yml"
-  when: (nginx_install | bool and nginx_install_from == "nginx_repository")
+  when: (nginx_enable | bool and nginx_install_from == "nginx_repository")
         or nginx_amplify_enable | bool
   tags: nginx_key
 
-- name: Install and Configure NGINX
+- name: "{{ nginx_setup | capitalize }} NGINX"
   block:
-    - name: Install NGINX
-      block:
-        - name: Install NGINX Open Source
-          include_tasks: "{{ role_path }}/tasks/opensource/install-oss.yml"
-          when: nginx_type == "opensource"
-          tags: nginx_install_oss
+    - name: "{{ nginx_setup | capitalize }} NGINX Open Source"
+      include_tasks: "{{ role_path }}/tasks/opensource/install-oss.yml"
+      when: nginx_type == "opensource"
+      tags: nginx_install_oss
 
-        - name: Set up NGINX Plus license
-          include_tasks: "{{ role_path }}/tasks/plus/setup-license.yml"
-          when:
-            - nginx_type == "plus"
-            - nginx_setup_license | bool
-          tags: nginx_setup_license
+    - name: Set up NGINX Plus license
+      include_tasks: "{{ role_path }}/tasks/plus/setup-license.yml"
+      when:
+        - nginx_type == "plus"
+        - nginx_setup_license | bool
+      tags: nginx_setup_license
 
-        - name: Install NGINX Plus
-          include_tasks: "{{ role_path }}/tasks/plus/install-{{ ansible_facts['os_family'] | lower }}.yml"
-          when: nginx_type == "plus"
-          tags: nginx_install_plus
+    - name: "{{ nginx_setup | capitalize }} NGINX Plus"
+      include_tasks: "{{ role_path }}/tasks/plus/install-{{ ansible_facts['os_family'] | lower }}.yml"
+      when: nginx_type == "plus"
+      tags: nginx_install_plus
 
-        - name: Install NGINX dynamic modules
-          include_tasks: "{{ role_path }}/tasks/modules/install-modules.yml"
-          when:
-            - nginx_modules is defined
-            - nginx_modules | length > 0
-          tags: nginx_install_modules
+    - name: "{{ nginx_setup | capitalize }} NGINX dynamic modules"
+      include_tasks: "{{ role_path }}/tasks/modules/install-modules.yml"
+      when:
+        - nginx_modules is defined
+        - nginx_modules | length > 0
+      tags: nginx_install_modules
 
-        - name: Remove NGINX Plus license
-          include_tasks: "{{ role_path }}/tasks/plus/remove-license.yml"
-          when:
-            - nginx_type == "plus"
-            - nginx_remove_license | bool
-          tags: nginx_remove_license
+    - name: Remove NGINX Plus license
+      include_tasks: "{{ role_path }}/tasks/plus/remove-license.yml"
+      when:
+        - nginx_type == "plus"
+        - nginx_remove_license | bool
+      tags: nginx_remove_license
 
-        - name: Modify systemd parameters
-          include_tasks: "{{ role_path }}/tasks/config/modify-systemd.yml"
-          when:
-            - ansible_facts['service_mgr'] == "systemd"
-            - nginx_service_modify | bool
-          tags: nginx_modify_systemd
-      when: nginx_install | bool
-      tags: nginx_install
-
-    - name: Ensure NGINX is running
-      meta: flush_handlers
-
-    - name: Debug NGINX output
-      include_tasks: "{{ role_path }}/tasks/config/debug-output.yml"
-      when: nginx_debug_output | bool
-      tags: nginx_debug_output
-
-    - name: Configure logrotate for NGINX
-      include_tasks: "{{ role_path }}/tasks/config/setup-logrotate.yml"
-      when: nginx_logrotate_conf_enable | bool
-      tags: nginx_logrotate_config
+    - name: Modify systemd parameters
+      include_tasks: "{{ role_path }}/tasks/config/modify-systemd.yml"
+      when:
+        - ansible_facts['service_mgr'] == "systemd"
+        - nginx_service_modify | bool
+      tags: nginx_modify_systemd
   when: nginx_enable | bool
+  tags: nginx_enable
+
+- name: Trigger handlers if necessary
+  meta: flush_handlers
+
+- name: Debug NGINX output
+  include_tasks: "{{ role_path }}/tasks/config/debug-output.yml"
+  when:
+    - nginx_debug_output | bool
+    - nginx_state != "absent"
+  tags: nginx_debug_output
+
+- name: Configure logrotate for NGINX
+  include_tasks: "{{ role_path }}/tasks/config/setup-logrotate.yml"
+  when:
+    - nginx_logrotate_conf_enable | bool
+    - nginx_state != "absent"
+  tags: nginx_logrotate_config
 
 - name: Install NGINX Amplify
   include_tasks: "{{ role_path }}/tasks/amplify/install-amplify.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Check that NGINX setup is an allowed value
   assert:
     that: nginx_setup in nginx_setup_vars
-    fail_msg: The value {{ nginx_setup }} you used for `nginx_setup` is not allowed. Try one of {{ nginx_setup_vars | join(, ) }}.
+    fail_msg: The value {{ nginx_setup }} you used for `nginx_setup` is not allowed. Try one of {{ nginx_setup_vars | join(', ') }}.
   when: nginx_enable | bool
   ignore_errors: true  # noqa ignore-errors
   tags: nginx_check_support

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -7,7 +7,7 @@
     - '"geoip" in nginx_modules'
     - nginx_install_epel_release | bool
 
-- name: Install NGINX modules
+- name: "Setup NGINX modules"
   package:
     name: "nginx-{{ (nginx_type == 'plus') | ternary('plus-', '') }}module-{{ item.name | default(item) }}\
           {{ item.version | default(nginx_version) | default('') }}{{ (nginx_repository is not defined and ansible_facts['os_family'] == 'Alpine' and nginx_type != 'plus') | ternary('@nginx', '') }}"

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -7,7 +7,7 @@
     - '"geoip" in nginx_modules'
     - nginx_install_epel_release | bool
 
-- name: "Setup NGINX modules"
+- name: Setup NGINX modules
   package:
     name: "nginx-{{ (nginx_type == 'plus') | ternary('plus-', '') }}module-{{ item.name | default(item) }}\
           {{ item.version | default(nginx_version) | default('') }}{{ (nginx_repository is not defined and ansible_facts['os_family'] == 'Alpine' and nginx_type != 'plus') | ternary('@nginx', '') }}"

--- a/tasks/opensource/install-alpine.yml
+++ b/tasks/opensource/install-alpine.yml
@@ -4,7 +4,7 @@
     path: /etc/apk/repositories
     insertafter: EOF
     line: "{{ nginx_repository | default(nginx_default_repository_alpine) }}"
-    state: "{{ nginx_state }}"
+    state: "{{ (nginx_state == 'uninstall') | ternary('absent', 'present') }}"
   when: nginx_manage_repo | bool
 
 - name: (Alpine Linux) {{ nginx_setup | capitalize }} NGINX

--- a/tasks/opensource/install-alpine.yml
+++ b/tasks/opensource/install-alpine.yml
@@ -1,14 +1,15 @@
 ---
-- name: (Alpine Linux) Configure NGINX repository
+- name: (Alpine Linux) {{ (nginx_setup == 'uninstall') | ternary('Remove', 'Configure') }} NGINX repository
   lineinfile:
     path: /etc/apk/repositories
     insertafter: EOF
     line: "{{ nginx_repository | default(nginx_default_repository_alpine) }}"
+    state: "{{ nginx_state }}"
   when: nginx_manage_repo | bool
 
-- name: (Alpine Linux) Install NGINX
+- name: (Alpine Linux) {{ nginx_setup | capitalize }} NGINX
   apk:
-    name: "nginx{{ nginx_repository is not defined | ternary('@nginx', '') }}{{ nginx_version | default('') }}"
+    name: "nginx{{ (nginx_repository is not defined and nginx_setup != 'uninstall') | ternary('@nginx', '') }}{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     update_cache: true
   ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/opensource/install-bsd.yml
+++ b/tasks/opensource/install-bsd.yml
@@ -14,16 +14,16 @@
     - ansible_facts['system'] == "FreeBSD"
     - nginx_bsd_update_ports | bool
 
-- name: (FreeBSD) Install NGINX
+- name: (FreeBSD) {{ nginx_setup | capitalize }} NGINX
   block:
-    - name: (FreeBSD) Install NGINX package
+    - name: (FreeBSD) {{ nginx_setup | capitalize }} NGINX package
       pkgng:
         name: "www/nginx{{ nginx_version | default('') }}"
         state: "{{ nginx_state }}"
       when: nginx_bsd_install_packages | bool
       notify: (Handler) Run NGINX
 
-    - name: (FreeBSD) Install NGINX port
+    - name: (FreeBSD) {{ nginx_setup | capitalize }} NGINX port
       portinstall:
         name: "www/nginx{{ nginx_version | default('') }}"
         use_packages: "{{ nginx_bsd_portinstall_use_packages | default(omit) }}"
@@ -32,9 +32,9 @@
       notify: (Handler) Run NGINX
   when: ansible_facts['system'] == "FreeBSD"
 
-- name: (OpenBSD) Install NGINX
+- name: (OpenBSD) {{ nginx_setup | capitalize }} NGINX
   block:
-    - name: (OpenBSD) Install NGINX package
+    - name: (OpenBSD) {{ nginx_setup | capitalize }} NGINX package
       openbsd_pkg:
         name: "nginx{{ nginx_version | default('') }}"
         build: false
@@ -42,7 +42,7 @@
       when: nginx_bsd_install_packages | bool
       notify: (Handler) Run NGINX
 
-    - name: (OpenBSD) Install NGINX port
+    - name: (OpenBSD) {{ nginx_setup | capitalize }} NGINX port
       openbsd_pkg:
         name: "nginx{{ nginx_version | default('') }}"
         build: true
@@ -51,28 +51,28 @@
       notify: (Handler) Run NGINX
   when: ansible_facts['system'] == "OpenBSD"
 
-- name: (NetBSD) Install NGINX
+- name: (NetBSD) {{ nginx_setup | capitalize }} NGINX
   block:
-    - name: (NetBSD) Install NGINX package
+    - name: (NetBSD) {{ nginx_setup | capitalize }} NGINX package
       command: "pkg_add www/nginx{{ nginx_version | default('') }}"
       when: nginx_bsd_install_packages | bool
       notify: (Handler) Run NGINX
 
-    - name: (NetBSD) Install NGINX port
+    - name: (NetBSD) {{ nginx_setup | capitalize }} NGINX port
       fail:
-        msg: "{{ ansible_facts['system'] }} Install NGINX port not implemented."
+        msg: "{{ ansible_facts['system'] }} {{ nginx_setup | capitalize }} NGINX port not implemented."
       when: not nginx_bsd_install_packages | bool
   when: ansible_facts['system'] == "NetBSD"
 
-- name: (DragonFlyBSD/HardenedBSD) Install NGINX
+- name: (DragonFlyBSD/HardenedBSD) {{ nginx_setup | capitalize }} NGINX
   block:
-    - name: (DragonFlyBSD/HardenedBSD) Install NGINX package
+    - name: (DragonFlyBSD/HardenedBSD) {{ nginx_setup | capitalize }} NGINX package
       command: "pkg install www/nginx{{ nginx_version | default('') }}"
       when: nginx_bsd_install_packages | bool
       notify: (Handler) Run NGINX
 
-    - name: (DragonFlyBSD/HardenedBSD) Install NGINX port
+    - name: (DragonFlyBSD/HardenedBSD) {{ nginx_setup | capitalize }} NGINX port
       fail:
-        msg: "{{ ansible_facts['system'] }} Install NGINX port not implemented."
+        msg: "{{ ansible_facts['system'] }} {{ nginx_setup | capitalize }} NGINX port not implemented."
       when: not nginx_bsd_install_packages | bool
   when: ansible_facts['system'] in ['DragonFlyBSD', 'HardenedBSD']

--- a/tasks/opensource/install-debian.yml
+++ b/tasks/opensource/install-debian.yml
@@ -5,7 +5,7 @@
     repo: "{{ item }}"
     update_cache: true
     mode: 0644
-    state: "{{ nginx_state }}"
+    state: "{{ (nginx_state == 'uninstall') | ternary('absent', 'present') }}"
   loop: "{{ nginx_repository | default(nginx_default_repository_debian) }}"
   when: nginx_manage_repo | bool
 
@@ -19,7 +19,7 @@
       Pin: release o=nginx
       Pin-Priority: 900
     mode: 0644
-    state: "{{ nginx_state }}"
+    state: "{{ (nginx_state == 'uninstall') | ternary('absent', 'present') }}"
   when: nginx_repository is not defined
 
 - name: (Debian/Ubuntu) {{ nginx_setup | capitalize }} NGINX

--- a/tasks/opensource/install-debian.yml
+++ b/tasks/opensource/install-debian.yml
@@ -1,14 +1,15 @@
 ---
-- name: (Debian/Ubuntu) Configure NGINX repository
+- name: (Debian/Ubuntu) {{ (nginx_setup == 'uninstall') | ternary('Remove', 'Configure') }} NGINX repository
   apt_repository:
     filename: nginx
     repo: "{{ item }}"
     update_cache: true
     mode: 0644
+    state: "{{ nginx_state }}"
   loop: "{{ nginx_repository | default(nginx_default_repository_debian) }}"
   when: nginx_manage_repo | bool
 
-- name: (Debian/Ubuntu) Pin NGINX repository
+- name: (Debian/Ubuntu) {{ (nginx_setup == 'uninstall') | ternary('Unpin', 'Pin') }} NGINX repository
   blockinfile:
     path: /etc/apt/preferences.d/99nginx
     create: true
@@ -18,9 +19,10 @@
       Pin: release o=nginx
       Pin-Priority: 900
     mode: 0644
+    state: "{{ nginx_state }}"
   when: nginx_repository is not defined
 
-- name: (Debian/Ubuntu) Install NGINX
+- name: (Debian/Ubuntu) {{ nginx_setup | capitalize }} NGINX
   apt:
     name: "nginx{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"

--- a/tasks/opensource/install-oss.yml
+++ b/tasks/opensource/install-oss.yml
@@ -1,15 +1,15 @@
 ---
-- name: Install NGINX in Linux systems
+- name: "{{ nginx_setup | capitalize }} NGINX in Linux systems"
   block:
-    - name: Install NGINX from repository
+    - name: "{{ nginx_setup | capitalize }} NGINX from repository"
       include_tasks: "{{ role_path }}/tasks/opensource/install-{{ ansible_facts['os_family'] | lower }}.yml"
       when: nginx_install_from == "nginx_repository"
 
-    - name: Install NGINX from source
+    - name: "{{ nginx_setup | capitalize }} NGINX from source"
       include_tasks: "{{ role_path }}/tasks/opensource/install-source.yml"
       when: nginx_install_from == "source"
 
-    - name: Install NGINX from package
+    - name: "{{ nginx_setup | capitalize }} NGINX from package"
       package:
         name: "nginx{{ nginx_version | default('') }}"
         state: "{{ nginx_state }}"
@@ -17,6 +17,6 @@
       notify: (Handler) Run NGINX
   when: ansible_facts['system'] | lower is not search('bsd')
 
-- name: Install NGINX in Unix systems
+- name: "{{ nginx_setup | capitalize }} NGINX in Unix systems"
   include_tasks: "{{ role_path }}/tasks/opensource/install-bsd.yml"
   when: ansible_facts['system'] | lower is search('bsd')

--- a/tasks/opensource/install-redhat.yml
+++ b/tasks/opensource/install-redhat.yml
@@ -1,5 +1,5 @@
 ---
-- name: (Amazon Linux/CentOS/RHEL) Configure NGINX repository
+- name: (Amazon Linux/CentOS/RHEL) {{ (nginx_setup == 'uninstall') | ternary('Remove', 'Configure') }} NGINX repository
   yum_repository:
     name: nginx
     baseurl: "{{ nginx_repository |
@@ -9,9 +9,10 @@
     gpgcheck: true
     mode: 0644
     module_hotfixes: true
+    state: "{{ nginx_state }}"
   when: nginx_manage_repo | bool
 
-- name: (Amazon Linux/CentOS/RHEL) Install NGINX
+- name: (Amazon Linux/CentOS/RHEL) {{ nginx_setup | capitalize }} NGINX
   yum:
     name: "nginx{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"

--- a/tasks/opensource/install-redhat.yml
+++ b/tasks/opensource/install-redhat.yml
@@ -9,7 +9,7 @@
     gpgcheck: true
     mode: 0644
     module_hotfixes: true
-    state: "{{ nginx_state }}"
+    state: "{{ (nginx_state == 'uninstall') | ternary('absent', 'present') }}"
   when: nginx_manage_repo | bool
 
 - name: (Amazon Linux/CentOS/RHEL) {{ nginx_setup | capitalize }} NGINX

--- a/tasks/opensource/install-suse.yml
+++ b/tasks/opensource/install-suse.yml
@@ -3,7 +3,7 @@
   zypper_repository:
     name: "nginx-{{ nginx_branch }}"
     repo: "{{ nginx_repository | default(nginx_default_repository_suse) }}"
-    state: "{{ nginx_state }}"
+    state: "{{ (nginx_state == 'uninstall') | ternary('absent', 'present') }}"
   when: nginx_manage_repo | bool
 
 - name: (SLES) {{ nginx_setup | capitalize }} NGINX

--- a/tasks/opensource/install-suse.yml
+++ b/tasks/opensource/install-suse.yml
@@ -1,11 +1,12 @@
 ---
-- name: (SLES) Configure NGINX repository
+- name: (SLES) {{ (nginx_setup == 'uninstall') | ternary('Remove', 'Configure') }} NGINX repository
   zypper_repository:
     name: "nginx-{{ nginx_branch }}"
     repo: "{{ nginx_repository | default(nginx_default_repository_suse) }}"
+    state: "{{ nginx_state }}"
   when: nginx_manage_repo | bool
 
-- name: (SLES) Install NGINX
+- name: (SLES) {{ nginx_setup | capitalize }} NGINX
   zypper:
     name: "nginx{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"

--- a/tasks/plus/install-alpine.yml
+++ b/tasks/plus/install-alpine.yml
@@ -4,10 +4,10 @@
     path: /etc/apk/repositories
     insertafter: EOF
     line: "{{ nginx_repository | default(nginx_plus_default_repository_alpine) }}"
-    state: "{{ nginx_license_status | default ('present') }}"
+    state: "{{ nginx_license_status | default((nginx_setup == 'uninstall') | ternary('absent', 'present')) }}"
   when: nginx_manage_repo | bool
 
-- name: (Alpine Linux) Install NGINX Plus
+- name: (Alpine Linux) {{ nginx_setup | capitalize }} NGINX Plus
   apk:
     name: "nginx-plus{{ nginx_version | default('') }}"
     repository: "{{ nginx_repository | default(nginx_plus_default_repository_alpine) }}"

--- a/tasks/plus/install-debian.yml
+++ b/tasks/plus/install-debian.yml
@@ -8,7 +8,7 @@
       Acquire::https::{{ (nginx_repository | default(nginx_plus_default_repository_debian)) | regex_search('(?<=https://)[^/]*') }}::Verify-Host "true";
       Acquire::https::{{ (nginx_repository | default(nginx_plus_default_repository_debian)) | regex_search('(?<=https://)[^/]*') }}::SslCert     "/etc/ssl/nginx/nginx-repo.crt";
       Acquire::https::{{ (nginx_repository | default(nginx_plus_default_repository_debian)) | regex_search('(?<=https://)[^/]*') }}::SslKey      "/etc/ssl/nginx/nginx-repo.key";
-    state: "{{ nginx_license_status | default ('present') }}"
+    state: "{{ nginx_license_status | default((nginx_setup == 'uninstall') | ternary('absent', 'present')) }}"
     mode: 0444
 
 - name: (Debian/Ubuntu) {{ nginx_license_status is defined | ternary('Remove', 'Configure') }} NGINX Plus repository
@@ -16,11 +16,11 @@
     filename: nginx-plus
     repo: "{{ nginx_repository | default(nginx_plus_default_repository_debian) }}"
     update_cache: false
-    state: "{{ nginx_license_status | default ('present') }}"
+    state: "{{ nginx_license_status | default((nginx_setup == 'uninstall') | ternary('absent', 'present')) }}"
     mode: 0644
   when: nginx_manage_repo | bool
 
-- name: (Debian/Ubuntu) Install NGINX Plus
+- name: (Debian/Ubuntu) {{ nginx_setup | capitalize }} NGINX Plus
   apt:
     name: "nginx-plus{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"

--- a/tasks/plus/install-freebsd.yml
+++ b/tasks/plus/install-freebsd.yml
@@ -22,7 +22,7 @@
     mode: 0644
   when: nginx_manage_repo | bool
 
-- name: (FreeBSD) Install NGINX Plus
+- name: (FreeBSD) {{ nginx_setup | capitalize }} NGINX Plus
   pkgng:
     name: "nginx-plus{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"

--- a/tasks/plus/install-redhat.yml
+++ b/tasks/plus/install-redhat.yml
@@ -1,5 +1,5 @@
 ---
-- name: (Amazon Linux/CentOS/Oracle Linux/RHEL) {{ nginx_license_status is defined | ternary('Remove', 'Configure') }} NGINX Plus repository
+- name: (Amazon Linux/CentOS/Oracle Linux/RHEL) {{ (nginx_license_status is defined or nginx_setup == 'uninstall') | ternary('Remove', 'Configure') }} NGINX Plus repository
   yum_repository:
     name: nginx-plus
     baseurl: "{{ nginx_repository |
@@ -9,11 +9,11 @@
     sslclientkey: /etc/ssl/nginx/nginx-repo.key
     enabled: true
     gpgcheck: true
-    state: "{{ nginx_license_status | default ('present') }}"
+    state: "{{ nginx_license_status | default((nginx_setup == 'uninstall') | ternary('absent', 'present')) }}"
     mode: 0644
   when: nginx_manage_repo | bool
 
-- name: (Amazon Linux/CentOS/Oracle Linux/RHEL) Install NGINX Plus
+- name: (Amazon Linux/CentOS/Oracle Linux/RHEL) {{ nginx_setup | capitalize }} NGINX Plus
   yum:
     name: "nginx-plus{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"

--- a/tasks/plus/install-suse.yml
+++ b/tasks/plus/install-suse.yml
@@ -1,19 +1,12 @@
 ---
-- name: (SLES) Combine NGINX Plus certificate and license key
-  assemble:
-    src: /etc/ssl/nginx
-    dest: /etc/ssl/nginx/nginx-repo-bundle.crt
-    mode: 0444
-  when: nginx_license_status is not defined
-
 - name: (SLES) {{ nginx_license_status is defined | ternary('Remove', 'Configure') }} NGINX Plus repository
   zypper_repository:
     name: nginx-plus
     repo: "{{ nginx_repository | default(nginx_plus_default_repository_suse) }}"
-    state: "{{ nginx_license_status | default ('present') }}"
+    state: "{{ nginx_license_status | default((nginx_setup == 'uninstall') | ternary('absent', 'present')) }}"
   when: nginx_manage_repo | bool
 
-- name: (SLES) Install NGINX Plus
+- name: (SLES) {{ nginx_setup | capitalize }} NGINX Plus
   zypper:
     name: "nginx-plus{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"

--- a/tasks/plus/setup-license.yml
+++ b/tasks/plus/setup-license.yml
@@ -40,3 +40,10 @@
         decrypt: true
         mode: 0444
   when: ansible_facts['os_family'] == "Alpine"
+
+- name: (SLES) Combine NGINX Plus certificate and license key
+  assemble:
+    src: /etc/ssl/nginx
+    dest: /etc/ssl/nginx/nginx-repo-bundle.crt
+    mode: 0444
+  when: ansible_facts['os_family'] == "Suse"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
-# nginx_setup_vars: [
-#   'install', 'uninstall', 'update',
-# ]
+nginx_setup_vars: [
+  'install', 'uninstall', 'update',
+]
 
 nginx_default_setup: install
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 nginx_setup_vars: [
-  'install', 'uninstall', 'update',
+  'install', 'uninstall', 'upgrade',
 ]
 
 nginx_default_setup: install
@@ -8,7 +8,7 @@ nginx_default_setup: install
 nginx_state_vals:
   install: present
   uninstall: absent
-  update: latest
+  upgrade: latest
 
 nginx_state: "{{ nginx_state_vals[nginx_setup] | default(nginx_state_vals[nginx_default_setup]) }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,17 @@
 ---
+# nginx_setup_vars: [
+#   'install', 'uninstall', 'update',
+# ]
+
+nginx_default_setup: install
+
+nginx_state_vals:
+  install: present
+  uninstall: absent
+  update: latest
+
+nginx_state: "{{ nginx_state_vals[nginx_setup] | default(nginx_state_vals[nginx_default_setup]) }}"
+
 # Supported NGINX Open Source distributions
 # https://nginx.org/en/docs/install.html
 nginx_distributions: [


### PR DESCRIPTION
### Proposed changes

BREAKING CHANGES:

* The `nginx_state` variable has been replaced with `nginx_setup` and instead of using `present`, `absent`, `latest` you should now use `install`, `uninstall` and `update`.
* `nginx_install` variable is no more. Use `nginx_enable` instead.

BUG FIXES:

Uninstalling NGINX should now work correctly under most scenarios.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
