### PR TITLE
Allow NGINX version downgrades

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         scenario:
           - default
+          - downgrade
           - module
           - plus
           - source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ BREAKING CHANGES:
 
 * The `nginx_state` variable has been replaced with `nginx_setup` and instead of using `present`, `absent`, `latest` you should now use `install`, `uninstall` and `upgrade`.
 * `nginx_install` variable is no more. Use `nginx_enable` instead.
+* Ansible core `2.12` is now a minimum requirement for the role.
 
 FEATURES:
 
-Pin repository data when installing NGINX OSS on Alpine and Debian distributions.
+* Pin repository data when installing NGINX OSS on Alpine and Debian distributions.
+* You can now downgrade versions of NGINX and switch from stable to mainline and viceversa. You will need to specify the NGINX branch and version you wish to install when tweaking versions.
 
 ENHANCEMENTS:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you wish to install NGINX Plus using this role, you will need to obtain an NG
 
 ### Ansible
 
-* This role is developed and tested with [maintained](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html) versions of Ansible core (above `2.11`).
+* This role is developed and tested with [maintained](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html) versions of Ansible core (above `2.12`).
 * When using Ansible core, you will also need to install the following collections:
 
     ```yaml

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
 
   license: Apache License, Version 2.0
 
-  min_ansible_version: 2.11
+  min_ansible_version: 2.12
 
   platforms:
     - name: Alpine

--- a/molecule/downgrade/converge.yml
+++ b/molecule/downgrade/converge.yml
@@ -1,0 +1,23 @@
+---
+- name: Converge
+  hosts: all
+  pre_tasks:
+    - name: Set repo if Alpine
+      set_fact:
+        version: "=1.20.2-r1"
+      when: ansible_facts['os_family'] == "Alpine"
+    - name: Set repo if Debian
+      set_fact:
+        version: "=1.20.2-1~{{ ansible_facts['distribution_release'] }}"
+      when: ansible_facts['os_family'] == "Debian"
+    - name: Set repo if Red Hat
+      set_fact:
+        version: "-1.20.2-1.{{ (ansible_facts['distribution']=='Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
+      when: ansible_facts['os_family'] == "RedHat"
+  tasks:
+    - name: Install NGINX
+      include_role:
+        name: ansible-role-nginx
+      vars:
+        nginx_version: "{{ version }}"
+        nginx_branch: stable

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -6,6 +6,27 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
+  - name: alpine-3.12
+    image: alpine:3.12
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.13
+    image: alpine:3.13
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.14
+    image: alpine:3.14
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
   - name: amazonlinux-2
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/downgrade/prepare.yml
+++ b/molecule/downgrade/prepare.yml
@@ -1,0 +1,29 @@
+---
+- name: Prepare
+  hosts: all
+  pre_tasks:
+    - name: Set repo if Alpine
+      set_fact:
+        version: "=1.21.4-r1"
+      when: ansible_facts['os_family'] == "Alpine"
+    - name: Set repo if Debian
+      set_fact:
+        version: "=1.21.4-1~{{ ansible_facts['distribution_release'] }}"
+      when: ansible_facts['os_family'] == "Debian"
+    - name: Set repo if Red Hat
+      set_fact:
+        version: "-1.21.4-1.{{ (ansible_facts['distribution']=='Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
+      when: ansible_facts['os_family'] == "RedHat"
+    - name: Enable NGINX @CentOS-AppStream dnf modules
+      shell:
+      args:
+        cmd: dnf module info nginx | grep -q 'Stream.*\[e\]' && echo -n ENABLED || dnf module enable -y nginx  # noqa command-instead-of-module
+      register: dnf_module_enable
+      changed_when: dnf_module_enable.stdout != 'ENABLED'
+      when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version'] is version('8', '==')
+  tasks:
+    - name: Install NGINX
+      include_role:
+        name: ansible-role-nginx
+      vars:
+        nginx_version: "{{ version }}"

--- a/molecule/downgrade/verify.yml
+++ b/molecule/downgrade/verify.yml
@@ -1,0 +1,33 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Check if NGINX is installed
+      package:
+        name: nginx
+        state: present
+      check_mode: true
+      register: install
+      failed_when: (install is changed) or (install is failed)
+
+    - name: Check if NGINX service is running
+      service:
+        name: nginx
+        state: started
+        enabled: true
+      check_mode: true
+      register: service
+      failed_when: (service is changed) or (service is failed)
+
+    - name: Verify NGINX is up and running
+      uri:
+        url: http://localhost
+        status_code: 200
+
+    # - name: Verify NGINX has been downgraded
+    #   command: nginx -v
+    #   args:
+    #     chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
+    #   changed_when: false
+    #   register: version
+    #   failed_when: version is not search('1.21.3')

--- a/tasks/opensource/install-debian.yml
+++ b/tasks/opensource/install-debian.yml
@@ -26,5 +26,7 @@
   apt:
     name: "nginx{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
+    update_cache: true
+    allow_downgrade: true
   ignore_errors: "{{ ansible_check_mode }}"
   notify: (Handler) Run NGINX

--- a/tasks/opensource/install-redhat.yml
+++ b/tasks/opensource/install-redhat.yml
@@ -17,5 +17,6 @@
     name: "nginx{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     update_cache: true
+    allow_downgrade: true
   ignore_errors: "{{ ansible_check_mode }}"
   notify: (Handler) Run NGINX

--- a/tasks/plus/install-debian.yml
+++ b/tasks/plus/install-debian.yml
@@ -25,6 +25,7 @@
     name: "nginx-plus{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     update_cache: true
+    allow_downgrade: true
   ignore_errors: "{{ ansible_check_mode }}"
   when: nginx_license_status is not defined
   notify: (Handler) Run NGINX

--- a/tasks/plus/install-redhat.yml
+++ b/tasks/plus/install-redhat.yml
@@ -18,6 +18,7 @@
     name: "nginx-plus{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     update_cache: true
+    allow_downgrade: true
   ignore_errors: "{{ ansible_check_mode }}"
   when: nginx_license_status is not defined
   notify: (Handler) Run NGINX


### PR DESCRIPTION
### Proposed changes

You can now downgrade versions of NGINX and switch from stable to mainline and viceversa. You will need to specify the NGINX branch and version you wish to install when tweaking versions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
