### PR TITLE
Cont: Feat ansible base compatibility

### DIFF
--- a/tasks/opensource/install-debian.yml
+++ b/tasks/opensource/install-debian.yml
@@ -27,6 +27,6 @@
     name: "nginx{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     update_cache: true
-    allow_downgrade: true
+    allow_downgrade: "{{ omit if ansible_version.full is version('2.12', '<') else true }}"
   ignore_errors: "{{ ansible_check_mode }}"
   notify: (Handler) Run NGINX

--- a/tasks/opensource/install-redhat.yml
+++ b/tasks/opensource/install-redhat.yml
@@ -17,6 +17,6 @@
     name: "nginx{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     update_cache: true
-    allow_downgrade: true
+    allow_downgrade: "{{ omit if ansible_version.full is version('2.12', '<') else true }}"
   ignore_errors: "{{ ansible_check_mode }}"
   notify: (Handler) Run NGINX

--- a/tasks/opensource/install-redhat.yml
+++ b/tasks/opensource/install-redhat.yml
@@ -8,7 +8,7 @@
     enabled: true
     gpgcheck: true
     mode: 0644
-    module_hotfixes: true
+    module_hotfixes: "{{ omit if ansible_version.full is version('2.11', '<') else true }}"
     state: "{{ (nginx_state == 'uninstall') | ternary('absent', 'present') }}"
   when: nginx_manage_repo | bool
 

--- a/tasks/plus/install-debian.yml
+++ b/tasks/plus/install-debian.yml
@@ -25,7 +25,7 @@
     name: "nginx-plus{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     update_cache: true
-    allow_downgrade: true
+    allow_downgrade: "{{ omit if ansible_version.full is version('2.12', '<') else true }}"
   ignore_errors: "{{ ansible_check_mode }}"
   when: nginx_license_status is not defined
   notify: (Handler) Run NGINX

--- a/tasks/plus/install-redhat.yml
+++ b/tasks/plus/install-redhat.yml
@@ -18,7 +18,7 @@
     name: "nginx-plus{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     update_cache: true
-    allow_downgrade: true
+    allow_downgrade: "{{ omit if ansible_version.full is version('2.12', '<') else true }}"
   ignore_errors: "{{ ansible_check_mode }}"
   when: nginx_license_status is not defined
   notify: (Handler) Run NGINX


### PR DESCRIPTION
### Proposed changes

Make role backward-compatble for Ansible versions 2.x, 3.x & 4 omitting recent module parameters when necessary.
Original PR and comments can be found here : https://github.com/nginxinc/ansible-role-nginx/pull/480
Looks like I cannot reopen it thus I must create a new one.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)

Resolves https://github.com/nginxinc/ansible-role-nginx/issues/478
