### PR TITLE
Add GPG key to Focal apt repo setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Support for ansible-base (ansible-core `<2.12`).
 BUG FIXES:
 
 The Molecule `upgrade` scenario verification test no longer has to be updated on each new NGINX OSS release.
+Add GPG key for Ubuntu Focal during APT repository setup.
 
 ## 0.22.0 (December 9, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Support for ansible-base (ansible-core `<2.12`).
 
 BUG FIXES:
 
-The Molecule `upgrade` scenario verification test no longer has to be updated on each new NGINX OSS release.
-Add GPG key for Ubuntu Focal during APT repository setup.
+* The Molecule `upgrade` scenario verification test no longer has to be updated on each new NGINX OSS release.
+* Add GPG key for Ubuntu Focal during APT repository setup.
 
 ## 0.22.0 (December 9, 2021)
 

--- a/tasks/amplify/setup-debian.yml
+++ b/tasks/amplify/setup-debian.yml
@@ -1,4 +1,12 @@
 ---
+
+- name: (Ubuntu 20.04) Add NGINX Amplify apt key
+  apt_key:
+    url: https://nginx.org/keys/nginx_signing.key
+    state: present
+  become: true
+  when: ansible_facts['distribution_release'] == "focal"
+
 - name: (Debian/Ubuntu) Add NGINX Amplify agent repository
   apt_repository:
     filename: nginx-amplify


### PR DESCRIPTION
Fix for #486

```
    amazon-ebs.nginx-ami: TASK [nginxinc.nginx : Configure logrotate for NGINX] **************************
    amazon-ebs.nginx-ami: skipping: [127.0.0.1]
    amazon-ebs.nginx-ami:
    amazon-ebs.nginx-ami: TASK [nginxinc.nginx : Install NGINX Amplify] **********************************
    amazon-ebs.nginx-ami: included: /tmp/packer-provisioner-ansible-local/62068329-15dc-016c-7d8f-8a91cf418710/roles/nginxinc.nginx/tasks/amplify/install-amplify.yml for 127.0.0.1
    amazon-ebs.nginx-ami:
    amazon-ebs.nginx-ami: TASK [nginxinc.nginx : Configure NGINX Amplify agent repository] ***************
    amazon-ebs.nginx-ami: included: /tmp/packer-provisioner-ansible-local/62068329-15dc-016c-7d8f-8a91cf418710/roles/nginxinc.nginx/tasks/amplify/setup-debian.yml for 127.0.0.1
    amazon-ebs.nginx-ami:
    amazon-ebs.nginx-ami: TASK [nginxinc.nginx : (Ubuntu 20.04) Add NGINX Amplify apt key] ***************
    amazon-ebs.nginx-ami: changed: [127.0.0.1]
    amazon-ebs.nginx-ami:
    amazon-ebs.nginx-ami: TASK [nginxinc.nginx : (Debian/Ubuntu) Add NGINX Amplify agent repository] *****
    amazon-ebs.nginx-ami: skipping: [127.0.0.1]
    amazon-ebs.nginx-ami:
    amazon-ebs.nginx-ami: TASK [nginxinc.nginx : (Ubuntu 20.04) Add NGINX Amplify agent repository] ******
    amazon-ebs.nginx-ami: changed: [127.0.0.1]
    amazon-ebs.nginx-ami:
    amazon-ebs.nginx-ami: TASK [nginxinc.nginx : Install NGINX Amplify agent] ****************************
    amazon-ebs.nginx-ami: changed: [127.0.0.1]
    amazon-ebs.nginx-ami:
```