### PR TITLE
Ansible check mode fails if NGINX is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.23.1 (Unreleased)
+
+BUG FIXES:
+
+Ansible check mode runs will no longer fail if NGINX has not yet been installed.
+
 ## 0.23.0 (February 16, 2022)
 
 BREAKING CHANGES:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -31,6 +31,7 @@
   failed_when: config_check.rc != 0
   when:
     - config_check.stderr_lines is defined
+    - config_check.stderr_lines != []
     - config_check.rc != 0
     - nginx_state != "absent"
   listen: (Handler) Run NGINX


### PR DESCRIPTION
### Proposed changes

Ansible check mode runs will no longer fail if NGINX has not yet been installed. Fixes #495.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [ ] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
