### PR TITLE
Rename modules to use Ansible FQCNs

### DIFF
--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,8 +1,8 @@
 ---
 collections:
   - name: community.general
-    version: 4.4.0
+    version: 4.6.1
   - name: ansible.posix
     version: 1.3.0
   - name: community.docker
-    version: 2.1.1
+    version: 2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 FEATURES:
 
-Add Molecule testing infrastructure for RHEL 7/8.
+* Add Molecule testing infrastructure for RHEL 7/8.
+* Rename all modules to use the fully qualified collection name (FQCN) per Ansible guidelines.
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ FEATURES:
 * Add Molecule testing infrastructure for RHEL 7/8.
 * Rename all modules to use the fully qualified collection name (FQCN) per Ansible guidelines.
 
+ENHANCEMENTS:
+
+Bump the Ansible `community.general` collection to `4.6.1` and `community.docker` collection to `2.2.1`.
+
 BUG FIXES:
 
 Ansible check mode runs will no longer fail if NGINX has not yet been installed.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -49,6 +49,5 @@ galaxy_info:
     - install
 
 collections:
-  - community.general
-  - ansible.builtin
   - ansible.posix
+  - community.general

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -47,3 +47,8 @@ galaxy_info:
     - server
     - development
     - install
+
+collections:
+  - community.general
+  - ansible.builtin
+  - ansible.posix

--- a/tasks/config/setup-logrotate.yml
+++ b/tasks/config/setup-logrotate.yml
@@ -1,6 +1,6 @@
 ---
 - name: (Alpine Linux) Install logrotate
-  apk:
+  community.general.apk:
     name: logrotate
   when: ansible_facts['os_family'] == "Alpine"
 
@@ -19,11 +19,11 @@
 - name: (SLES) Set up logrotate
   block:
     - name: (SLES) Configure logrotate repository
-      zypper_repository:
+      community.general.zypper_repository:
         repo: https://download.opensuse.org/repositories/openSUSE:Leap:42.1/standard/openSUSE:Leap:42.1.repo
 
     - name: (SLES) Install Logrotate
-      zypper:
+      community.general.zypper:
         name: logrotate
         state: present
   when: ansible_facts['os_family'] == "Suse"

--- a/tasks/opensource/install-alpine.yml
+++ b/tasks/opensource/install-alpine.yml
@@ -8,7 +8,7 @@
   when: nginx_manage_repo | bool
 
 - name: (Alpine Linux) {{ nginx_setup | capitalize }} NGINX
-  apk:
+  community.general.apk:
     name: "nginx{{ (nginx_repository is not defined and nginx_setup != 'uninstall') | ternary('@nginx', '') }}{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     update_cache: true

--- a/tasks/opensource/install-bsd.yml
+++ b/tasks/opensource/install-bsd.yml
@@ -17,14 +17,14 @@
 - name: (FreeBSD) {{ nginx_setup | capitalize }} NGINX
   block:
     - name: (FreeBSD) {{ nginx_setup | capitalize }} NGINX package
-      pkgng:
+      community.general.pkgng:
         name: "www/nginx{{ nginx_version | default('') }}"
         state: "{{ nginx_state }}"
       when: nginx_bsd_install_packages | bool
       notify: (Handler) Run NGINX
 
     - name: (FreeBSD) {{ nginx_setup | capitalize }} NGINX port
-      portinstall:
+      community.general.portinstall:
         name: "www/nginx{{ nginx_version | default('') }}"
         use_packages: "{{ nginx_bsd_portinstall_use_packages | default(omit) }}"
         state: "{{ nginx_state }}"
@@ -35,7 +35,7 @@
 - name: (OpenBSD) {{ nginx_setup | capitalize }} NGINX
   block:
     - name: (OpenBSD) {{ nginx_setup | capitalize }} NGINX package
-      openbsd_pkg:
+      community.general.openbsd_pkg:
         name: "nginx{{ nginx_version | default('') }}"
         build: false
         state: "{{ nginx_state }}"
@@ -43,7 +43,7 @@
       notify: (Handler) Run NGINX
 
     - name: (OpenBSD) {{ nginx_setup | capitalize }} NGINX port
-      openbsd_pkg:
+      community.general.openbsd_pkg:
         name: "nginx{{ nginx_version | default('') }}"
         build: true
         state: "{{ nginx_state }}"

--- a/tasks/opensource/install-source.yml
+++ b/tasks/opensource/install-source.yml
@@ -12,7 +12,7 @@
             update_cache: true
 
         - name: (RHEL 8) Set Python 3 as default
-          alternatives:
+          community.general.alternatives:
             name: python
             path: /usr/bin/python3
             link: /usr/bin/python
@@ -60,7 +60,7 @@
       when: ansible_facts['os_family'] == "Debian"
 
     - name: (Alpine Linux) Install build tools
-      apk:
+      community.general.apk:
         name:
           - alpine-sdk
           - build-base
@@ -118,7 +118,7 @@
     - ansible_facts['os_family'] == "Debian"
 
 - name: (Alpine Linux) Install PCRE dependency from package
-  apk:
+  community.general.apk:
     name: pcre-dev
     update_cache: true
   when:
@@ -148,11 +148,11 @@
         creates: "/tmp/makefile"
 
     - name: Make PCRE dependency
-      make:
+      community.general.make:
         chdir: "/tmp/{{ pcre_version }}"
 
     - name: Install PCRE dependency
-      make:
+      community.general.make:
         chdir: "/tmp/{{ pcre_version }}"
         target: install
   when:
@@ -177,7 +177,7 @@
     - ansible_facts['os_family'] == "Debian"
 
 - name: (Alpine Linux) Install ZLib dependency from package
-  apk:
+  community.general.apk:
     name: zlib-dev
     update_cache: true
   when:
@@ -207,11 +207,11 @@
         creates: "/tmp/makefile"
 
     - name: Make ZLib dependency
-      make:
+      community.general.make:
         chdir: "/tmp/{{ zlib_version }}"
 
     - name: Install ZLib dependency
-      make:
+      community.general.make:
         chdir: "/tmp/{{ zlib_version }}"
         target: install
   when:
@@ -236,7 +236,7 @@
     - ansible_facts['os_family'] == "Debian"
 
 - name: (Alpine Linux) Install OpenSSL dependency from package
-  apk:
+  community.general.apk:
     name: openssl-dev
     update_cache: true
   when:
@@ -266,11 +266,11 @@
         creates: "/tmp/makefile"
 
     - name: Make OpenSSL dependency
-      make:
+      community.general.make:
         chdir: "/tmp/{{ openssl_version }}"
 
     - name: Install OpenSSL dependency
-      make:
+      community.general.make:
         chdir: "/tmp/{{ openssl_version }}"
         target: install
   when:
@@ -344,11 +344,11 @@
       register: nginx_configure
 
     - name: Make NGINX
-      make:
+      community.general.make:
         chdir: "/tmp/{{ nginx_version }}"
 
     - name: Install NGINX
-      make:
+      community.general.make:
         chdir: "/tmp/{{ nginx_version }}"
         target: install
 

--- a/tasks/opensource/install-suse.yml
+++ b/tasks/opensource/install-suse.yml
@@ -1,13 +1,13 @@
 ---
 - name: (SLES) {{ (nginx_setup == 'uninstall') | ternary('Remove', 'Configure') }} NGINX repository
-  zypper_repository:
+  community.general.zypper_repository:
     name: "nginx-{{ nginx_branch }}"
     repo: "{{ nginx_repository | default(nginx_default_repository_suse) }}"
     state: "{{ (nginx_state == 'uninstall') | ternary('absent', 'present') }}"
   when: nginx_manage_repo | bool
 
 - name: (SLES) {{ nginx_setup | capitalize }} NGINX
-  zypper:
+  community.general.zypper:
     name: "nginx{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     disable_recommends: false

--- a/tasks/plus/install-alpine.yml
+++ b/tasks/plus/install-alpine.yml
@@ -8,7 +8,7 @@
   when: nginx_manage_repo | bool
 
 - name: (Alpine Linux) {{ nginx_setup | capitalize }} NGINX Plus
-  apk:
+  community.general.apk:
     name: "nginx-plus{{ nginx_version | default('') }}"
     repository: "{{ nginx_repository | default(nginx_plus_default_repository_alpine) }}"
     state: "{{ nginx_state }}"

--- a/tasks/plus/install-freebsd.yml
+++ b/tasks/plus/install-freebsd.yml
@@ -23,7 +23,7 @@
   when: nginx_manage_repo | bool
 
 - name: (FreeBSD) {{ nginx_setup | capitalize }} NGINX Plus
-  pkgng:
+  community.general.pkgng:
     name: "nginx-plus{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
   when: nginx_license_status is not defined

--- a/tasks/plus/install-suse.yml
+++ b/tasks/plus/install-suse.yml
@@ -1,13 +1,13 @@
 ---
 - name: (SLES) {{ nginx_license_status is defined | ternary('Remove', 'Configure') }} NGINX Plus repository
-  zypper_repository:
+  community.general.zypper_repository:
     name: nginx-plus
     repo: "{{ nginx_repository | default(nginx_plus_default_repository_suse) }}"
     state: "{{ nginx_license_status | default((nginx_setup == 'uninstall') | ternary('absent', 'present')) }}"
   when: nginx_manage_repo | bool
 
 - name: (SLES) {{ nginx_setup | capitalize }} NGINX Plus
-  zypper:
+  community.general.zypper:
     name: "nginx-plus{{ nginx_version | default('') }}"
     state: "{{ nginx_state }}"
     update_cache: true

--- a/tasks/prerequisites/install-dependencies.yml
+++ b/tasks/prerequisites/install-dependencies.yml
@@ -1,6 +1,6 @@
 ---
 - name: (Alpine Linux) Install dependencies
-  apk:
+  community.general.apk:
     name: "{{ nginx_alpine_dependencies }}"
     update_cache: true
     state: latest  # noqa package-latest
@@ -21,7 +21,7 @@
   when: ansible_facts['os_family'] == "RedHat"
 
 - name: (SLES) Install dependencies
-  zypper:
+  community.general.zypper:
     name: "{{ nginx_sles_dependencies }}"
     update_cache: true
     state: latest  # noqa package-latest
@@ -30,13 +30,13 @@
 - name: (FreeBSD) Install dependencies
   block:
     - name: (FreeBSD) Install dependencies using package(s)
-      pkgng:
+      community.general.pkgng:
         name: "{{ nginx_freebsd_dependencies }}"
         state: latest  # noqa package-latest
       when: nginx_bsd_install_packages | bool
 
     - name: (FreeBSD) Install dependencies using port(s)
-      portinstall:
+      community.general.portinstall:
         name: "{{ item }}"
         use_packages: "{{ nginx_bsd_portinstall_use_packages | default(omit) }}"
         state: latest  # noqa package-latest

--- a/tasks/prerequisites/setup-selinux.yml
+++ b/tasks/prerequisites/setup-selinux.yml
@@ -18,24 +18,24 @@
   when: ansible_facts['os_family'] == "RedHat"
 
 - name: Set SELinux mode to permissive
-  selinux:
+  ansible.builtin.selinux:
     state: permissive
     policy: targeted
 
 - name: Allow SELinux HTTP network connections
-  seboolean:
+  ansible.builtin.seboolean:
     name: httpd_can_network_connect
     state: true
     persistent: true
 
 - name: Allow SELinux HTTP network connections
-  seboolean:
+  ansible.builtin.seboolean:
     name: httpd_can_network_relay
     state: true
     persistent: true
 
 - name: Allow SELinux TCP connections on specific ports
-  seport:
+  community.general.seport:
     ports: "{{ nginx_selinux_tcp_ports }}"
     proto: tcp
     setype: http_port_t
@@ -43,7 +43,7 @@
   when: nginx_selinux_tcp_ports is defined
 
 - name: Allow SELinux UDP connections on specific ports
-  seport:
+  community.general.seport:
     ports: "{{ nginx_selinux_udp_ports }}"
     proto: udp
     setype: http_port_t
@@ -75,7 +75,7 @@
   when: nginx_selinux_module.changed | bool
 
 - name: Set SELinux mode to enforcing
-  selinux:
+  ansible.builtin.selinux:
     state: enforcing
     policy: targeted
   when: nginx_selinux_enforcing | bool


### PR DESCRIPTION
### Proposed changes

* Rename all modules to use the fully qualified collection name (FQCN) per Ansible guidelines.
* Bump the Ansible `community.general` collection to `4.6.1` and `community.docker` collection to `2.2.1`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
