### PR TITLE
Add `TimeoutStartSec` parameter

### DIFF
--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -5,4 +5,4 @@ collections:
   - name: ansible.posix
     version: 1.3.0
   - name: community.docker
-    version: 2.2.1
+    version: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ FEATURES:
 
 ENHANCEMENTS:
 
-* Bump the Ansible `community.general` collection to `4.6.1` and `community.docker` collection to `2.2.1`.
+* Bump the Ansible `community.general` collection to `4.6.1` and `community.docker` collection to `2.3.0`.
 * Streamline configuring SELinux.
+* Add `TimeoutStartSec` parameter to Systemd template.
 
 BUG FIXES:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you wish to install NGINX Plus using this role, you will need to obtain an NG
       - name: ansible.posix
         version: 1.3.0
       - name: community.docker  # Only required if you plan to use Molecule (see below)
-        version: 2.2.1
+        version: 2.3.0
     ```
 
     **Note:** You can alternatively install the Ansible community distribution (what is known as the "old" Ansible) if you don't want to manage individual collections.

--- a/defaults/main/systemd.yml
+++ b/defaults/main/systemd.yml
@@ -14,10 +14,12 @@ nginx_service_overridepath: /etc/systemd/system/nginx.service.d
 # Default is override.conf
 nginx_service_overridefilename: override.conf
 
-# Set service timeout for systemd systems in seconds (default: 90)
+# Set service timeout for systemd systems in seconds
 # [Service]
+# TimeoutStartSec=90
 # TimeoutStopSec=90
 # Default is to comment this out
+# nginx_service_timeoutstartsec: 90
 # nginx_service_timeoutstopsec: 90
 
 # Set the restart policy for systemd systems

--- a/templates/services/nginx.service.override.conf.j2
+++ b/templates/services/nginx.service.override.conf.j2
@@ -1,6 +1,9 @@
 [Service]
+{% if nginx_service_timeoutstartsec is defined %}
+TimeoutStartSec={{ nginx_service_timeoutstartsec }}
+{% endif %}
 {% if nginx_service_timeoutstopsec is defined %}
-TimeoutStopSec={{ nginx_service_timeoutstopsec | default(90) }}
+TimeoutStopSec={{ nginx_service_timeoutstopsec }}
 {% endif %}
 {% if nginx_service_restartonfailure is defined %}
 Restart=on-failure


### PR DESCRIPTION
### Proposed changes

Add `TimeoutStartSec` parameter to Systemd template and bump `community.docker` collection to `2.3.0`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
