### PR TITLE
Ensure `gpg-agent` is installed on Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.23.2 (April 11, 2022)
+
+BUG FIXES:
+
+Ensure gpg-agent is installed on Ubuntu/Debian to avoid APT key tasks failures.
+
 ## 0.23.1 (April 6, 2022)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.23.2 (April 11, 2022)
+## 0.23.2 (Unreleased)
 
 BUG FIXES:
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -62,7 +62,7 @@ nginx_alpine_dependencies: [
 
 # Debian dependencies
 nginx_debian_dependencies: [
-  'apt-transport-https', 'ca-certificates',
+  'apt-transport-https', 'ca-certificates', 'gpg-agent',
 ]
 
 # Red Hat dependencies


### PR DESCRIPTION
### Proposed changes

Makes sure `gpg-agent` is present on Ubuntu systems before importing the apt keys, as outlined in #507.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))