### PR TITLE
Bump Ansible collections

### DIFF
--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,8 +1,8 @@
 ---
 collections:
   - name: community.general
-    version: 4.7.0
+    version: 5.0.0
   - name: ansible.posix
-    version: 1.3.0
+    version: 1.4.0
   - name: community.docker
-    version: 2.3.0
+    version: 2.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ FEATURES:
 
 ENHANCEMENTS:
 
-Tweak Release Drafter config.
+* Tweak Release Drafter config.
+* Bump the Ansible `community.general` collection to `5.0.0`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.6.0`.
 
 BUG FIXES:
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ If you wish to install NGINX Plus using this role, you will need to obtain an NG
     ---
     collections:
       - name: community.general
-        version: 4.7.0
+        version: 5.0.0
       - name: ansible.posix
-        version: 1.3.0
+        version: 1.4.0
       - name: community.docker  # Only required if you plan to use Molecule (see below)
-        version: 2.3.0
+        version: 2.6.0
     ```
 
     **Note:** You can alternatively install the Ansible community distribution (what is known as the "old" Ansible) if you don't want to manage individual collections.


### PR DESCRIPTION
### Proposed changes

Bump the Ansible `community.general` collection to `5.0.0`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.6.0`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
