### PR TITLE
NGINX Plus does not yet support RHEL 9

### DIFF
--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -62,13 +62,6 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/usr/sbin/init"
-  - name: rhel-9
-    image: registry.access.redhat.com/ubi9/ubi:9.0.0
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/usr/sbin/init"
   - name: debian-buster
     image: debian:buster-slim
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/uninstall_plus/molecule.yml
+++ b/molecule/uninstall_plus/molecule.yml
@@ -62,13 +62,6 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/usr/sbin/init"
-  - name: rhel-9
-    image: registry.access.redhat.com/ubi9/ubi:9.0.0
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/usr/sbin/init"
   - name: debian-buster
     image: debian:buster-slim
     dockerfile: ../common/Dockerfile.j2


### PR DESCRIPTION
### Proposed changes

Remove RHEL 9 tests involving NGINX Plus.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
