### PR TITLE
Add Alpine Linux 3.16 as a supported platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ FEATURES:
 
 * Add support for NGINX OSS on Ubuntu jammy (22.04).
 * Add CODEOWNERS file.
-* Add support for NGINX OSS on RHEL 9.
+* Add RHEL 9 to the NGINX OSS list of tested and supported platforms.
+* Add Alpine Linux 3.16 to the NGINX OSS list of tested and supported platforms (and remove Alpine Linux 3.12).
 
 ENHANCEMENTS:
 
@@ -47,10 +48,10 @@ FEATURES:
 
 * Backwards support for older versions of Ansible (e.g. Ansible `<2.12`).
 * Update NGINX Amplify repositories to use Python 3 when possible.
+* Add Alpine Linux 3.15 to the NGINX Plus list of tested and supported platforms (and remove Alpine Linux 3.11).
 
 ENHANCEMENTS:
 
-* Add Alpine Linux 3.15 to the NGINX Plus list of tested and supported platforms (and remove Alpine Linux 3.11).
 * Use `pcre2` by default when possible.
 * Bump the Ansible `community.general` collection to `4.4.0` and `community.docker` collection to `2.1.1`.
 
@@ -71,10 +72,10 @@ FEATURES:
 
 * Pin repository data when installing NGINX OSS on Alpine and Debian distributions.
 * You can now downgrade versions of NGINX and switch from stable to mainline and viceversa. You will need to specify the NGINX branch and version you wish to install when tweaking versions.
+* Add Alpine Linux 3.15 to the NGINX OSS list of tested and supported platforms (and remove Alpine Linux 3.11).
 
 ENHANCEMENTS:
 
-* Add Alpine Linux 3.15 to the NGINX OSS list of tested and supported platforms (and remove Alpine Linux 3.11).
 * Bump the Ansible `community.general` collection to `4.1.0` and `community.docker` collection to `2.0.2`.
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ The NGINX Ansible role supports all platforms supported by [NGINX Open Source](h
 
 ```yaml
 Alpine:
-  - 3.12
   - 3.13
   - 3.14
   - 3.15
+  - 3.16
 Amazon Linux:
   - 2
 CentOS:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,13 +6,6 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.12
-    image: alpine:3.12
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
   - name: alpine-3.13
     image: alpine:3.13
     dockerfile: ../common/Dockerfile.j2
@@ -29,6 +22,13 @@ platforms:
     command: "/sbin/init"
   - name: alpine-3.15
     image: alpine:3.15
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.16
+    image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/molecule/module/molecule.yml
+++ b/molecule/module/molecule.yml
@@ -6,13 +6,6 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.12
-    image: alpine:3.12
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
   - name: alpine-3.13
     image: alpine:3.13
     dockerfile: ../common/Dockerfile.j2
@@ -29,6 +22,13 @@ platforms:
     command: "/sbin/init"
   - name: alpine-3.15
     image: alpine:3.15
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.16
+    image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -6,13 +6,6 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.12
-    image: alpine:3.12
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
   - name: alpine-3.13
     image: alpine:3.13
     dockerfile: ../common/Dockerfile.j2
@@ -29,6 +22,13 @@ platforms:
     command: "/sbin/init"
   - name: alpine-3.15
     image: alpine:3.15
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.16
+    image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -6,13 +6,6 @@ lint: |
   yamllint .
   ansible-lint --force-color
 platforms:
-  - name: alpine-3.12
-    image: alpine:3.12
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    volumes:
-      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
-    command: "/sbin/init"
   - name: alpine-3.13
     image: alpine:3.13
     dockerfile: ../common/Dockerfile.j2
@@ -29,6 +22,13 @@ platforms:
     command: "/sbin/init"
   - name: alpine-3.15
     image: alpine:3.15
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
+  - name: alpine-3.16
+    image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     volumes:


### PR DESCRIPTION
### Proposed changes

Add Alpine Linux 3.16 to the NGINX OSS list of tested and supported platforms (and remove Alpine Linux 3.12).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
