### PR TITLE
Add source support for PCRE 2 and OpenSSL 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ FEATURES:
 
 ENHANCEMENTS:
 
+* Add support for PCRE 2 and OpenSSL 3.0 (built from source) when building NGINX from source.
 * Tweak Release Drafter config.
 * Bump the Ansible `community.general` collection to `5.1.1`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.6.0`.
 

--- a/molecule/common/Dockerfile.j2
+++ b/molecule/common/Dockerfile.j2
@@ -25,7 +25,7 @@ RUN \
     && dnf clean all; \
   elif [ $(command -v yum) ]; then \
     yum makecache fast \
-    && yum install -y bash iproute initscripts sudo /usr/bin/python /usr/bin/python2-config vim yum-plugin-ovl http://mirror.centos.org/centos/7/os/x86_64/Packages/pcre2-10.23-2.el7.x86_64.rpm \
+    && yum install -y bash iproute initscripts sudo /usr/bin/python /usr/bin/python2-config vim yum-plugin-ovl \
     && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf \
     && yum clean all; \
   elif [ $(command -v zypper) ]; then \

--- a/tasks/opensource/install-source.yml
+++ b/tasks/opensource/install-source.yml
@@ -25,6 +25,7 @@
         name:
           - ca-certificates
           - gcc
+          - gcc-c++
           - gd
           - gd-devel
           - glibc
@@ -103,7 +104,7 @@
 
 - name: (CentOS/RHEL) Install PCRE dependency from package
   ansible.builtin.yum:
-    name: pcre-devel
+    name: "{{ pcre_release == 2 | ternary('pcre2-devel', 'pcre-devel') }}"
     update_cache: true
   when:
     - nginx_install_source_pcre | bool
@@ -111,7 +112,7 @@
 
 - name: (Debian/Ubuntu) Install PCRE dependency from package
   ansible.builtin.apt:
-    name: libpcre3-dev
+    name: "{{ pcre_release == 2 | ternary('libpcre2-dev', 'libpcre3-dev') }}"
     update_cache: true
   when:
     - nginx_install_source_pcre | bool
@@ -119,7 +120,7 @@
 
 - name: (Alpine Linux) Install PCRE dependency from package
   community.general.apk:
-    name: pcre-dev
+    name: "{{ pcre_release == 2 | ternary('pcre2-dev', 'pcre-dev') }}"
     update_cache: true
   when:
     - nginx_install_source_pcre | bool
@@ -129,7 +130,7 @@
   block:
     - name: Download PCRE dependency
       ansible.builtin.get_url:
-        url: "https://ftp.exim.org/pub/pcre/{{ pcre_version }}.tar.gz"
+        url: "{{ (pcre_release == 2) | ternary('https://github.com/PCRE2Project/pcre2/releases/download/' ~ pcre_version ~ '/' ~ pcre_version ~ '.tar.gz', 'https://ftp.exim.org/pub/pcre/' ~ pcre_version ~ '.tar.gz') }}"
         dest: "/tmp/{{ pcre_version }}.tar.gz"
         mode: 0600
       register: pcre_source

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -80,10 +80,12 @@ nginx_freebsd_dependencies: [
   'security/ca_root_nss',
 ]
 
-# Default locations and versions when 'nginx_install_from' is set to 'source'
-pcre_version: pcre-8.45
-zlib_version: zlib-1.2.11
-openssl_version: openssl-1.1.1m
+# Default locations and versions when 'nginx_install_from' is set to 'source'.
+# Set 'pcre_release' to 1 to install PCRE 1, modify the 'openssl_version' to move back to 1.1.1.
+pcre_release: 2
+pcre_version: pcre2-10.40
+zlib_version: zlib-1.2.12
+openssl_version: openssl-3.0.4
 
 # Supported NGINX Open Source dynamic modules
 nginx_modules_list: [


### PR DESCRIPTION
### Proposed changes

Add support for PCRE 2 and OpenSSL 3.0 (built from source) when building NGINX from source.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
