### PR TITLE
Add Ubuntu jammy to downgrade and upgrade tests

### DIFF
--- a/molecule/downgrade/converge.yml
+++ b/molecule/downgrade/converge.yml
@@ -4,11 +4,11 @@
   pre_tasks:
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: "=1.20.2-1~{{ ansible_facts['distribution_release'] }}"
+        version: "=1.22.0-1~{{ ansible_facts['distribution_release'] }}"
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: "-1.20.2-1.{{ (ansible_facts['distribution'] == 'Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
+        version: "-1.22.0-1.{{ (ansible_facts['distribution'] == 'Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
       when: ansible_facts['os_family'] == "RedHat"
   tasks:
     - name: Install NGINX

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -69,6 +69,13 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/sbin/init"
+  - name: ubuntu-jammy
+    image: ubuntu:jammy
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/downgrade/prepare.yml
+++ b/molecule/downgrade/prepare.yml
@@ -2,10 +2,6 @@
 - name: Prepare
   hosts: all
   pre_tasks:
-    - name: Set repo if Alpine
-      ansible.builtin.set_fact:
-        version: "=1.23.0-r1"
-      when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
         version: "=1.23.0-1~{{ ansible_facts['distribution_release'] }}"

--- a/molecule/downgrade/prepare.yml
+++ b/molecule/downgrade/prepare.yml
@@ -4,15 +4,15 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: "=1.21.5-r1"
+        version: "=1.23.0-r1"
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: "=1.21.5-1~{{ ansible_facts['distribution_release'] }}"
+        version: "=1.23.0-1~{{ ansible_facts['distribution_release'] }}"
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: "-1.21.6-1.{{ (ansible_facts['distribution'] == 'Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
+        version: "-1.23.0-1.{{ (ansible_facts['distribution'] == 'Amazon') | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx"
       when: ansible_facts['os_family'] == "RedHat"
   tasks:
     - name: Install NGINX

--- a/molecule/downgrade/verify.yml
+++ b/molecule/downgrade/verify.yml
@@ -24,10 +24,21 @@
         url: http://localhost
         status_code: 200
 
+    - name: Fetch NGINX version
+      ansible.builtin.uri:
+        url: https://version.nginx.com/nginx/stable
+        return_content: true
+      check_mode: false
+      register: nginx_versions
+
+    - name: Set NGINX version
+      ansible.builtin.set_fact:
+        nginx_version: "{{ nginx_versions.content | regex_search('([0-9]+\\.){2}[0-9]+') }}"
+
     - name: Verify NGINX has been downgraded
       ansible.builtin.command: nginx -v
       args:
         chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
       changed_when: false
       register: version
-      failed_when: version is not search('1.20.2')
+      failed_when: version is not search(nginx_version)

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -69,6 +69,13 @@ platforms:
     volumes:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/sbin/init"
+  - name: ubuntu-jammy
+    image: ubuntu:jammy
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    volumes:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/sbin/init"
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/upgrade/prepare.yml
+++ b/molecule/upgrade/prepare.yml
@@ -2,13 +2,9 @@
 - name: Prepare
   hosts: all
   pre_tasks:
-    - name: Set repo if Alpine
-      ansible.builtin.set_fact:
-        version: "=1.21.5-r1"
-      when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: "=1.21.5-1~{{ ansible_facts['distribution_release'] }}"
+        version: "=1.21.6-1~{{ ansible_facts['distribution_release'] }}"
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:


### PR DESCRIPTION
### Proposed changes

Ubuntu jammy was missing from both the downgrade and upgrade tests due to a lack of NGINX releases to test both scenarios.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
