### PR TITLE
Update GitHub actions to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -8,7 +8,7 @@ name: Ansible Galaxy import
 jobs:
   galaxy:
     name: Galaxy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out the codebase
         uses: actions/checkout@v3

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -45,11 +45,6 @@ jobs:
       - name: Install Ansible core dependencies
         run: ansible-galaxy install -r .github/workflows/requirements/requirements_ansible.yml
 
-      - name: Reset Docker
-        run: |
-          sudo rm /etc/docker/daemon.json
-          sudo systemctl restart docker
-
       - name: Run Molecule tests
         if: ${{ env.NGINX_CRT != 0 && env.NGINX_KEY != 0 }}
         run: molecule test -s ${{ matrix.scenario }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Install Ansible core dependencies
         run: ansible-galaxy install -r .github/workflows/requirements/requirements_ansible.yml
 
+      - name: Reset Docker
+        run: |
+          sudo rm /etc/docker/daemon.json
+          sudo systemctl restart docker
+
       - name: Run Molecule tests
         if: ${{ env.NGINX_CRT != 0 && env.NGINX_KEY != 0 }}
         run: molecule test -s ${{ matrix.scenario }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -15,7 +15,7 @@ name: Molecule CI/CD
 jobs:
   molecule:
     name: Molecule
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,7 +13,7 @@ name: Release Drafter
 jobs:
   update_release_draft:
     name: Update release draft
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: release-drafter/release-drafter@v5
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ BUG FIXES:
 
 * Fix an issue when installing the GeoIP2 module on an UBI 7 container where the the `libmaxminddb` package dependency might not be available via `yum` (if it's not available, `libmaxminddb` is installed from an external source).
 
+TESTS:
+
+* Update GitHub actions to run on Ubuntu 22.04. Amazon Linux 2 does not support cgroups v2 so the corresponding Molecule tests have been removed.
+* Update GitHub actions to only skip \*plus\* scenarios when the NGINX Plus license secrets are not present (it used to only run the NGINX Plus test scenarios during internal PRs).
+
 ## 0.23.2 (September 28, 2022)
 
 FEATURES:
@@ -36,7 +41,6 @@ BUG FIXES:
 
 TESTS:
 
-* Update GitHub actions to run on Ubuntu 22.04 and to only skip ~plus~ scenarios when the NGINX Plus license secrets are not present (it used to only run the scenarios during internal PRs).
 * Add SLES 15 to all Molecule tests.
 * Create downgrade and upgrade tests for NGINX Plus.
 * Remove Yamllint (Ansible Lint now incorporates Yamllint).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ BUG FIXES:
 
 TESTS:
 
-* Update GitHub actions to only skip \*plus\* scenarios when the NGINX Plus license secrets are not present (it used to only run the NGINX Plus test scenarios during internal PRs).
+* Update GitHub actions to run on Ubuntu 22.04 and to only skip ~plus~ scenarios when the NGINX Plus license secrets are not present (it used to only run the scenarios during internal PRs).
 * Add SLES 15 to all Molecule tests.
 * Create downgrade and upgrade tests for NGINX Plus.
 * Remove Yamllint (Ansible Lint now incorporates Yamllint).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ BUG FIXES:
 TESTS:
 
 * Update GitHub actions to run on Ubuntu 22.04. Amazon Linux 2 does not support cgroups v2 so the corresponding Molecule tests have been removed.
-* Update GitHub actions to only skip \*plus\* scenarios when the NGINX Plus license secrets are not present (it used to only run the NGINX Plus test scenarios during internal PRs).
 
 ## 0.23.2 (September 28, 2022)
 
@@ -41,6 +40,7 @@ BUG FIXES:
 
 TESTS:
 
+* Update GitHub actions to only skip \*plus\* scenarios when the NGINX Plus license secrets are not present (it used to only run the NGINX Plus test scenarios during internal PRs).
 * Add SLES 15 to all Molecule tests.
 * Create downgrade and upgrade tests for NGINX Plus.
 * Remove Yamllint (Ansible Lint now incorporates Yamllint).

--- a/molecule/common/Dockerfile.j2
+++ b/molecule/common/Dockerfile.j2
@@ -26,6 +26,9 @@ RUN \
   elif [ $(command -v yum) ]; then \
     yum makecache fast \
     && yum install -y bash iproute initscripts sudo /usr/bin/python /usr/bin/python2-config vim yum-plugin-ovl \
+    && yum install -y http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-plugin-copr-1.1.31-54.el7_8.noarch.rpm	http://mirror.centos.org/centos/7/os/x86_64/Packages/libseccomp-2.3.1-4.el7.x86_64.rpm \
+    && yum copr enable -y jsynacek/systemd-backports-for-centos-7 \
+    && yum update -y systemd \
     && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf \
     && yum clean all; \
   elif [ $(command -v zypper) ]; then \

--- a/molecule/common/Dockerfile.j2
+++ b/molecule/common/Dockerfile.j2
@@ -26,7 +26,7 @@ RUN \
   elif [ $(command -v yum) ]; then \
     yum makecache fast \
     && yum install -y bash iproute initscripts sudo /usr/bin/python /usr/bin/python2-config vim yum-plugin-ovl \
-    && yum install -y http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-plugin-copr-1.1.31-54.el7_8.noarch.rpm	http://mirror.centos.org/centos/7/os/x86_64/Packages/libseccomp-2.3.1-4.el7.x86_64.rpm \
+    && yum install -y http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-plugin-copr-1.1.31-54.el7_8.noarch.rpm http://mirror.centos.org/centos/7/os/x86_64/Packages/libseccomp-2.3.1-4.el7.x86_64.rpm \
     && yum copr enable -y jsynacek/systemd-backports-for-centos-7 \
     && yum update -y systemd \
     && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf \

--- a/molecule/common/Dockerfile.j2
+++ b/molecule/common/Dockerfile.j2
@@ -28,7 +28,7 @@ RUN \
     && yum install -y bash iproute initscripts sudo /usr/bin/python /usr/bin/python2-config vim yum-plugin-ovl \
     && yum install -y http://mirror.centos.org/centos/7/os/x86_64/Packages/yum-plugin-copr-1.1.31-54.el7_8.noarch.rpm http://mirror.centos.org/centos/7/os/x86_64/Packages/libseccomp-2.3.1-4.el7.x86_64.rpm \
     && yum copr enable -y jsynacek/systemd-backports-for-centos-7 \
-    && yum update -y systemd \
+    && yum update --disableplugin=priorities -y systemd \
     && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf \
     && yum clean all; \
   elif [ $(command -v zypper) ]; then \

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ platforms:
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -22,6 +23,7 @@ platforms:
   - name: alpine-3.14
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -29,6 +31,7 @@ platforms:
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -36,6 +39,7 @@ platforms:
   - name: alpine-3.16
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -50,6 +54,7 @@ platforms:
   - name: amazonlinux-2
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -57,6 +62,7 @@ platforms:
   - name: centos-7
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -92,6 +98,7 @@ platforms:
   - name: rhel-7
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -99,6 +106,7 @@ platforms:
   - name: rhel-8
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -106,6 +114,7 @@ platforms:
   - name: rhel-9
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -113,6 +122,7 @@ platforms:
   - name: rockylinux-8
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -120,6 +130,7 @@ platforms:
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -134,6 +145,7 @@ platforms:
   - name: ubuntu-bionic
     image: ubuntu:bionic
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -141,6 +153,7 @@ platforms:
   - name: ubuntu-focal
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -148,6 +161,7 @@ platforms:
   - name: ubuntu-jammy
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
+    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,6 @@ platforms:
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -23,7 +22,6 @@ platforms:
   - name: alpine-3.14
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -31,7 +29,6 @@ platforms:
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -39,7 +36,6 @@ platforms:
   - name: alpine-3.16
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -54,7 +50,6 @@ platforms:
   - name: amazonlinux-2
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -62,7 +57,6 @@ platforms:
   - name: centos-7
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -98,7 +92,6 @@ platforms:
   - name: rhel-7
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -106,7 +99,6 @@ platforms:
   - name: rhel-8
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -114,7 +106,6 @@ platforms:
   - name: rhel-9
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -122,7 +113,6 @@ platforms:
   - name: rockylinux-8
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -130,7 +120,6 @@ platforms:
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -145,7 +134,6 @@ platforms:
   - name: ubuntu-bionic
     image: ubuntu:bionic
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -153,7 +141,6 @@ platforms:
   - name: ubuntu-focal
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -161,7 +148,6 @@ platforms:
   - name: ubuntu-jammy
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
-    cgroupns: host
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     image: almalinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -48,6 +49,7 @@ platforms:
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -72,6 +74,7 @@ platforms:
     image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -79,6 +82,7 @@ platforms:
     image: oraclelinux:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -86,6 +90,7 @@ platforms:
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -93,6 +98,7 @@ platforms:
     image: oraclelinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -140,6 +146,7 @@ platforms:
     image: registry.suse.com/bci/bci-base:15.4
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,6 +9,7 @@ platforms:
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -23,6 +24,7 @@ platforms:
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -30,6 +32,7 @@ platforms:
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -37,6 +40,7 @@ platforms:
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -51,6 +55,7 @@ platforms:
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -58,6 +63,7 @@ platforms:
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -100,6 +106,7 @@ platforms:
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -107,6 +114,7 @@ platforms:
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -121,6 +129,7 @@ platforms:
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -135,6 +144,7 @@ platforms:
     image: ubuntu:bionic
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -142,6 +152,7 @@ platforms:
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -149,6 +160,7 @@ platforms:
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -56,7 +56,6 @@ platforms:
   - name: amazonlinux-2
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
-    platform: amd64
     privileged: true
     cgroupns_mode: host
     volumes:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -55,7 +55,6 @@ platforms:
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
-    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -63,7 +62,6 @@ platforms:
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
-    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -122,6 +120,7 @@ platforms:
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -53,14 +53,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: amazonlinux-2
-    image: amazonlinux:2
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
+  # - name: amazonlinux-2
+  #   image: amazonlinux:2
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /usr/sbin/init
   - name: centos-7
     image: centos:7
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -55,6 +55,7 @@ platforms:
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -54,6 +54,7 @@ platforms:
   - name: amazonlinux-2
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
+    platform: amd64
     privileged: true
     cgroupns_mode: host
     volumes:
@@ -62,7 +63,9 @@ platforms:
   - name: centos-7
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
+    platform: amd64
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -97,7 +100,9 @@ platforms:
   - name: rhel-7
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
+    platform: amd64
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -53,14 +53,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: amazonlinux-2
-  #   image: amazonlinux:2
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /usr/sbin/init
+  - name: amazonlinux-2
+    image: amazonlinux:2
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
   - name: centos-7
     image: centos:7
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -63,7 +63,6 @@ platforms:
   - name: centos-7
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
-    platform: amd64
     privileged: true
     cgroupns_mode: host
     volumes:
@@ -100,7 +99,6 @@ platforms:
   - name: rhel-7
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
-    platform: amd64
     privileged: true
     cgroupns_mode: host
     volumes:

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -9,6 +9,7 @@ platforms:
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -23,6 +24,7 @@ platforms:
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -30,6 +32,7 @@ platforms:
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -37,6 +40,7 @@ platforms:
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -58,6 +62,7 @@ platforms:
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -93,6 +98,7 @@ platforms:
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -100,6 +106,7 @@ platforms:
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -107,6 +114,7 @@ platforms:
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -114,6 +122,7 @@ platforms:
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -121,6 +130,7 @@ platforms:
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -128,6 +138,7 @@ platforms:
     image: registry.suse.com/bci/bci-base:15.4
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -135,6 +146,7 @@ platforms:
     image: ubuntu:bionic
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -142,6 +154,7 @@ platforms:
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -149,6 +162,7 @@ platforms:
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     image: almalinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -48,6 +49,7 @@ platforms:
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -55,6 +57,7 @@ platforms:
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -70,6 +73,7 @@ platforms:
     image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -77,6 +81,7 @@ platforms:
     image: oraclelinux:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -84,6 +89,7 @@ platforms:
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -91,6 +97,7 @@ platforms:
     image: oraclelinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/downgrade_plus/molecule.yml
+++ b/molecule/downgrade_plus/molecule.yml
@@ -23,6 +23,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: alpine:3.13
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -30,6 +31,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -37,6 +39,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -58,6 +61,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -93,6 +97,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -100,6 +105,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -107,6 +113,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -114,6 +121,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -121,6 +129,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -128,6 +137,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: registry.suse.com/bci/bci-base:15.4
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -135,6 +145,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: ubuntu:bionic
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -142,6 +153,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -149,6 +161,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init

--- a/molecule/downgrade_plus/molecule.yml
+++ b/molecule/downgrade_plus/molecule.yml
@@ -9,6 +9,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -16,6 +17,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: almalinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -47,6 +49,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -54,6 +57,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -69,6 +73,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -76,6 +81,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: oraclelinux:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -83,6 +89,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -90,6 +97,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: oraclelinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/module/molecule.yml
+++ b/molecule/module/molecule.yml
@@ -9,6 +9,7 @@ platforms:
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -23,6 +24,7 @@ platforms:
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -30,6 +32,7 @@ platforms:
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -37,6 +40,7 @@ platforms:
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -58,6 +62,7 @@ platforms:
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -93,6 +98,7 @@ platforms:
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -100,6 +106,7 @@ platforms:
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -107,6 +114,7 @@ platforms:
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -114,6 +122,7 @@ platforms:
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -121,6 +130,7 @@ platforms:
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -128,6 +138,7 @@ platforms:
     image: registry.suse.com/bci/bci-base:15.4
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -135,6 +146,7 @@ platforms:
     image: ubuntu:bionic
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -142,6 +154,7 @@ platforms:
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -149,6 +162,7 @@ platforms:
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init

--- a/molecule/module/molecule.yml
+++ b/molecule/module/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     image: almalinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -48,6 +49,7 @@ platforms:
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -55,6 +57,7 @@ platforms:
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -70,6 +73,7 @@ platforms:
     image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -77,6 +81,7 @@ platforms:
     image: oraclelinux:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -84,6 +89,7 @@ platforms:
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -91,6 +97,7 @@ platforms:
     image: oraclelinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -9,6 +9,7 @@ platforms:
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -16,6 +17,7 @@ platforms:
     image: almalinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -55,6 +57,7 @@ platforms:
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -62,6 +65,7 @@ platforms:
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -77,6 +81,7 @@ platforms:
     image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -84,6 +89,7 @@ platforms:
     image: oraclelinux:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -91,6 +97,7 @@ platforms:
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -98,6 +105,7 @@ platforms:
     image: oraclelinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -23,6 +23,7 @@ platforms:
     image: alpine:3.13
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -30,6 +31,7 @@ platforms:
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -37,6 +39,7 @@ platforms:
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -44,6 +47,7 @@ platforms:
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -65,6 +69,7 @@ platforms:
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -100,6 +105,7 @@ platforms:
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -107,6 +113,7 @@ platforms:
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -114,6 +121,7 @@ platforms:
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -121,6 +129,7 @@ platforms:
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -128,6 +137,7 @@ platforms:
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -135,6 +145,7 @@ platforms:
     image: registry.suse.com/bci/bci-base:15.4
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -142,6 +153,7 @@ platforms:
     image: ubuntu:bionic
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -149,6 +161,7 @@ platforms:
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -156,6 +169,7 @@ platforms:
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -17,6 +17,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: almalinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -48,6 +49,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -55,6 +57,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -70,6 +73,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -77,6 +81,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -84,6 +89,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: oraclelinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -91,6 +97,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -98,6 +105,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -145,6 +153,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: registry.suse.com/bci/bci-base:15.4
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -9,6 +9,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -23,6 +24,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -30,6 +32,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -37,6 +40,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -58,6 +62,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -100,6 +105,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -107,6 +113,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -114,6 +121,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -121,6 +129,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -128,6 +137,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -142,6 +152,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: ubuntu:bionic
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -149,6 +160,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -156,6 +168,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -9,6 +9,7 @@ platforms:
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -23,6 +24,7 @@ platforms:
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -30,6 +32,7 @@ platforms:
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -37,6 +40,7 @@ platforms:
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -58,6 +62,7 @@ platforms:
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -93,6 +98,7 @@ platforms:
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -100,6 +106,7 @@ platforms:
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -107,6 +114,7 @@ platforms:
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -114,6 +122,7 @@ platforms:
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -121,6 +130,7 @@ platforms:
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -128,6 +138,7 @@ platforms:
     image: registry.suse.com/bci/bci-base:15.4
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -135,6 +146,7 @@ platforms:
     image: ubuntu:bionic
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -142,6 +154,7 @@ platforms:
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -149,6 +162,7 @@ platforms:
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     image: almalinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -48,6 +49,7 @@ platforms:
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -55,6 +57,7 @@ platforms:
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -70,6 +73,7 @@ platforms:
     image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -77,6 +81,7 @@ platforms:
     image: oraclelinux:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -84,6 +89,7 @@ platforms:
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -91,6 +97,7 @@ platforms:
     image: oraclelinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/uninstall_plus/molecule.yml
+++ b/molecule/uninstall_plus/molecule.yml
@@ -9,6 +9,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -16,6 +17,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: almalinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -55,6 +57,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -62,6 +65,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -77,6 +81,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -84,6 +89,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: oraclelinux:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -91,6 +97,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -98,6 +105,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: oraclelinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -137,6 +145,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/uninstall_plus/molecule.yml
+++ b/molecule/uninstall_plus/molecule.yml
@@ -23,6 +23,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: alpine:3.13
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -30,6 +31,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -37,6 +39,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -44,6 +47,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -65,6 +69,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -100,6 +105,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -107,6 +113,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -114,6 +121,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -121,6 +129,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -135,6 +144,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: registry.suse.com/bci/bci-base:15.4
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -142,6 +152,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -149,6 +160,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -9,6 +9,7 @@ platforms:
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -23,6 +24,7 @@ platforms:
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -30,6 +32,7 @@ platforms:
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -37,6 +40,7 @@ platforms:
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -58,6 +62,7 @@ platforms:
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -65,6 +70,7 @@ platforms:
     image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -135,6 +141,7 @@ platforms:
     image: ubuntu:bionic
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -142,6 +149,7 @@ platforms:
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -149,6 +157,7 @@ platforms:
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     image: almalinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -48,6 +49,7 @@ platforms:
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -55,6 +57,7 @@ platforms:
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -78,6 +81,7 @@ platforms:
     image: oraclelinux:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -85,6 +89,7 @@ platforms:
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -92,6 +97,7 @@ platforms:
     image: oraclelinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -99,6 +105,7 @@ platforms:
     image: registry.access.redhat.com/ubi7:7.9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -106,6 +113,7 @@ platforms:
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -113,6 +121,7 @@ platforms:
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -120,6 +129,7 @@ platforms:
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -127,6 +137,7 @@ platforms:
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -134,6 +145,7 @@ platforms:
     image: registry.suse.com/bci/bci-base:15.4
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init

--- a/molecule/upgrade_plus/molecule.yml
+++ b/molecule/upgrade_plus/molecule.yml
@@ -23,6 +23,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: alpine:3.13
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -30,6 +31,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: alpine:3.14
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -37,6 +39,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -58,6 +61,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: centos:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -93,6 +97,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: registry.access.redhat.com/ubi7/ubi:7.9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -100,6 +105,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: redhat/ubi8:8.7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -107,6 +113,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: redhat/ubi9:9.1.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -114,6 +121,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -121,6 +129,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: rockylinux:9.0.20220720
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -128,6 +137,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: registry.suse.com/bci/bci-base:15.4
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -135,6 +145,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: ubuntu:bionic
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -142,6 +153,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: ubuntu:focal
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -149,6 +161,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: ubuntu:jammy
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init

--- a/molecule/upgrade_plus/molecule.yml
+++ b/molecule/upgrade_plus/molecule.yml
@@ -9,6 +9,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -16,6 +17,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: almalinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -47,6 +49,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: alpine:3.16
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -54,6 +57,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: amazonlinux:2
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -69,6 +73,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: debian:bullseye-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
@@ -76,6 +81,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: oraclelinux:7
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -83,6 +89,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
@@ -90,6 +97,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     image: oraclelinux:9
     dockerfile: ../common/Dockerfile.j2
     privileged: true
+    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init


### PR DESCRIPTION
### Proposed changes

Update GitHub actions to run on Ubuntu 22.04 and to only skip ~plus~ scenarios when the NGINX Plus license secrets are not present (it used to only run the scenarios during internal PRs).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
