### PR TITLE
Bump Ansible collections

### DIFF
--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,10 +1,10 @@
 ---
 collections:
   - name: community.general
-    version: 5.4.0
+    version: 5.5.0
   - name: ansible.posix
     version: 1.4.0
   - name: community.crypto
     version: 2.5.0
   - name: community.docker
-    version: 2.7.0
+    version: 3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ ENHANCEMENTS:
 
 * Add support for PCRE 2 and OpenSSL 3.0 (built from source) when building NGINX from source.
 * Tweak Release Drafter config.
-* Bump the Ansible `community.general` collection to `5.4.0`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `2.7.0`.
+* Bump the Ansible `community.general` collection to `5.5.0`, `ansible.posix` collection to `1.4.0` and `community.docker` collection to `3.0.2`.
 * Re-add Alpine Linux tests to `downgrade` Molecule scenarios.
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ If you wish to install NGINX Plus using this role, you will need to obtain an NG
     ---
     collections:
       - name: community.general
-        version: 5.4.0
+        version: 5.5.0
       - name: ansible.posix
         version: 1.4.0
       - name: community.crypto # Only required if you plan to install NGINX Plus
         version: 2.5.0
       - name: community.docker # Only required if you plan to use Molecule (see below)
-        version: 2.7.0
+        version: 3.0.2
     ```
 
     **Note:** You can alternatively install the Ansible community distribution (what is known as the "old" Ansible) if you don't want to manage individual collections.

--- a/molecule/downgrade_plus/prepare.yml
+++ b/molecule/downgrade_plus/prepare.yml
@@ -5,14 +5,14 @@
   tasks:
     - name: Create ephemeral license certificate file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_CRT') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_CRT') | b64decode }}"
         dest: ../../files/license/nginx-repo.crt
         force: false
         mode: 0444
 
     - name: Create ephemeral license key file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_KEY') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_KEY') | b64decode }}"
         dest: ../../files/license/nginx-repo.key
         force: false
         mode: 0444

--- a/molecule/plus/prepare.yml
+++ b/molecule/plus/prepare.yml
@@ -5,14 +5,14 @@
   tasks:
     - name: Create ephemeral license certificate file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_CRT') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_CRT') | b64decode }}"
         dest: ../../files/license/nginx-repo.crt
         force: false
         mode: 0444
 
     - name: Create ephemeral license key file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_KEY') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_KEY') | b64decode }}"
         dest: ../../files/license/nginx-repo.key
         force: false
         mode: 0444

--- a/molecule/uninstall_plus/prepare.yml
+++ b/molecule/uninstall_plus/prepare.yml
@@ -5,14 +5,14 @@
   tasks:
     - name: Create ephemeral license certificate file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_CRT') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_CRT') | b64decode }}"
         dest: ../../files/license/nginx-repo.crt
         force: false
         mode: 0444
 
     - name: Create ephemeral license key file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_KEY') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_KEY') | b64decode }}"
         dest: ../../files/license/nginx-repo.key
         force: false
         mode: 0444

--- a/molecule/upgrade_plus/prepare.yml
+++ b/molecule/upgrade_plus/prepare.yml
@@ -5,14 +5,14 @@
   tasks:
     - name: Create ephemeral license certificate file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_CRT') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_CRT') | b64decode }}"
         dest: ../../files/license/nginx-repo.crt
         force: false
         mode: 0444
 
     - name: Create ephemeral license key file from b64 decoded env var
       ansible.builtin.copy:
-        content: "{{ lookup('env','NGINX_KEY') | b64decode }}"
+        content: "{{ lookup('env', 'NGINX_KEY') | b64decode }}"
         dest: ../../files/license/nginx-repo.key
         force: false
         mode: 0444

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,8 @@
   ansible.builtin.assert:
     that: (nginx_type == "opensource" and ansible_facts['distribution'] in nginx_distributions)
           or (nginx_type == "plus" and ansible_facts['distribution'] in nginx_plus_distributions)
-    success_msg: Your OS, {{ ansible_facts['distribution'] }} is supported by NGINX {{ (nginx_type=='plus') | ternary('Plus', 'Open Source') }}
-    fail_msg: Your OS, {{ ansible_facts['distribution'] }} is not supported by NGINX {{ (nginx_type=='plus') | ternary('Plus', 'Open Source') }}
+    success_msg: Your OS, {{ ansible_facts['distribution'] }} is supported by NGINX {{ (nginx_type == 'plus') | ternary('Plus', 'Open Source') }}
+    fail_msg: Your OS, {{ ansible_facts['distribution'] }} is not supported by NGINX {{ (nginx_type == 'plus') | ternary('Plus', 'Open Source') }}
   when:
     - nginx_enable | bool
     - (nginx_install_from == "nginx_repository" or nginx_type == "plus")

--- a/tasks/plus/install-freebsd.yml
+++ b/tasks/plus/install-freebsd.yml
@@ -6,7 +6,7 @@
       PKG_ENV: { SSL_NO_VERIFY_PEER: "1",
       SSL_CLIENT_CERT_FILE: "/etc/ssl/nginx/nginx-repo.crt",
       SSL_CLIENT_KEY_FILE: "/etc/ssl/nginx/nginx-repo.key" }
-    state: "{{ nginx_license_status | default ('present') }}"
+    state: "{{ nginx_license_status | default('present') }}"
 
 - name: (FreeBSD) {{ nginx_license_status is defined | ternary('Remove', 'Configure') }} NGINX Plus repository
   ansible.builtin.blockinfile:
@@ -18,7 +18,7 @@
       ENABLED: yes
       MIRROR_TYPE: SRV
       }
-    state: "{{ nginx_license_status | default ('present') }}"
+    state: "{{ nginx_license_status | default('present') }}"
     mode: 0644
   when: nginx_manage_repo | bool
 


### PR DESCRIPTION
### Proposed changes

Bump the Ansible `community.general` collection to `5.5.0` and `community.docker` collection to `3.0.2`, and address Linter warnings.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
