### PR TITLE
Fix tests not running on external PRs

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -16,6 +16,9 @@ jobs:
   molecule:
     name: Molecule
     runs-on: ubuntu-22.04
+    env:
+      NGINX_CRT: ${{ secrets.NGINX_CRT }}
+      NGINX_KEY: ${{ secrets.NGINX_KEY }}
     strategy:
       fail-fast: false
       matrix:
@@ -55,5 +58,3 @@ jobs:
         env:
           PY_COLORS: 1
           ANSIBLE_FORCE_COLOR: 1
-          NGINX_CRT: ${{ secrets.NGINX_CRT }}
-          NGINX_KEY: ${{ secrets.NGINX_KEY }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -32,21 +32,25 @@ jobs:
           - upgrade_plus
     steps:
       - name: Check out the codebase
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         uses: actions/checkout@v3
 
       - name: Set up Python 3
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         uses: actions/setup-python@v4
         with:
           python-version: 3.x
 
       - name: Install Molecule dependencies
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         run: pip3 install -r .github/workflows/requirements/requirements_molecule.txt
 
       - name: Install Ansible core dependencies
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         run: ansible-galaxy install -r .github/workflows/requirements/requirements_ansible.yml
 
       - name: Run Molecule tests
-        if: ${{ env.NGINX_CRT != 0 && env.NGINX_KEY != 0 }}
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         run: molecule test -s ${{ matrix.scenario }}
         env:
           PY_COLORS: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ FEATURES:
 BUG FIXES:
 
 * Fix an issue when installing the GeoIP2 module on an UBI 7 container where the the `libmaxminddb` package dependency might not be available via `yum` (if it's not available, `libmaxminddb` is installed from an external source).
+* GitHub actions should now correctly skip \*plus\* scenarios only when the NGINX Plus license secrets are not present.
 
 TESTS:
 


### PR DESCRIPTION
### Proposed changes

GitHub actions should now correctly skip \*plus\* scenarios only when the NGINX Plus license secrets are not present.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
