### PR TITLE
Bump Ansible collections

### DIFF
--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,10 +1,10 @@
 ---
 collections:
-  - name: community.general
-    version: 5.5.0
   - name: ansible.posix
     version: 1.4.0
-  - name: community.crypto
-    version: 2.5.0
-  - name: community.docker
-    version: 3.1.0
+  - name: community.general
+    version: 6.2.0
+  - name: community.crypto # Only required if you plan to install NGINX Plus
+    version: 2.10.0
+  - name: community.docker # Only required if you plan to use Molecule
+    version: 3.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ FEATURES:
 * Add AlmaLinux, Oracle Linux and Rocky Linux to the list of NGINX OSS and NGINX Plus tested and supported platforms.
 * Add Alpine Linux 3.17 to the NGINX list of tested and supported platforms (and remove Alpine Linux 3.13 from the list of NGINX OSS supported platforms).
 
+ENHANCEMENTS:
+
+Bump the Ansible `community.general` collection to `6.2.0`, `community.crypto` collection to `2.10.0` and `community.docker` collection to `3.4.0`.
+
 BUG FIXES:
 
 * Fix an issue when installing the GeoIP2 module on an UBI 7 container where the the `libmaxminddb` package dependency might not be available via `yum` (if it's not available, `libmaxminddb` is installed from an external source).

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ If you wish to install NGINX Plus using this role, you will need to obtain an NG
       - name: ansible.posix
         version: 1.4.0
       - name: community.general
-        version: 5.5.0
+        version: 6.2.0
       - name: community.crypto # Only required if you plan to install NGINX Plus
-        version: 2.5.0
+        version: 2.10.0
       - name: community.docker # Only required if you plan to use Molecule (see below)
-        version: 3.1.0
+        version: 3.4.0
     ```
 
     **Note:** You can alternatively install the Ansible community distribution (what is known as the "old" Ansible) if you don't want to manage individual collections.


### PR DESCRIPTION
### Proposed changes

Bump the Ansible `community.general` collection to `6.2.0`, `community.crypto` collection to `2.10.0` and `community.docker` collection to `3.4.0`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
