### PR TITLE
Improve workflow for building NGINX from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@ BREAKING CHANGES:
 
 * When building from source the various libraries required to build NGINX from source, you will no longer need to specify the name of the package, only the version:
 
-```yaml
-pcre_version: pcre2-10.42
-```
+  ```yaml
+  pcre_version: pcre2-10.42
+  ```
 
-is now:
+  is now:
 
-```yaml
-pcre_version: 10.42
-```
+  ```yaml
+  pcre_version: 10.42
+  ```
 
 * The `nginx_install_source_<package>: false` parameters have been reversed. Setting `nginx_install_source_pcre: true` will now build PCRE from source, instead of using the default package manager. The previous behavior was unintuitive at best.
 
@@ -32,7 +32,7 @@ BUG FIXES:
 
 * Fix an issue when installing the GeoIP2 module on an UBI 7 container where the the `libmaxminddb` package dependency might not be available via `yum` (if it's not available, `libmaxminddb` is installed from an external source).
 * GitHub actions should now correctly skip \*plus\* scenarios only when the NGINX Plus license secrets are not present.
-* Update the versions of the various packages required to build NGINX from source.
+* Update the versions of the various packages required to build NGINX from source. The version of `zlib` listed in the role was no longer available.
 
 TESTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## 0.23.3 (Unreleased)
 
+BREAKING CHANGES:
+
+* When building from source the various libraries required to build NGINX from source, you will no longer need to specify the name of the package, only the version:
+
+```yaml
+pcre_version: pcre2-10.42
+```
+
+is now:
+
+```yaml
+pcre_version: 10.42
+```
+
+* The `nginx_install_source_<package>: false` parameters have been reversed. Setting `nginx_install_source_pcre: true` will now build PCRE from source, instead of using the default package manager. The previous behavior was unintuitive at best.
+
 FEATURES:
 
 * Add AlmaLinux, Oracle Linux and Rocky Linux to the list of NGINX OSS and NGINX Plus tested and supported platforms.
@@ -9,12 +25,14 @@ FEATURES:
 
 ENHANCEMENTS:
 
-Bump the Ansible `community.general` collection to `6.2.0`, `community.crypto` collection to `2.10.0` and `community.docker` collection to `3.4.0`.
+* Bump the Ansible `community.general` collection to `6.2.0`, `community.crypto` collection to `2.10.0` and `community.docker` collection to `3.4.0`.
+* Use the official GitHub repositories as the source for the various packages required to compile NGINX OSS from source.
 
 BUG FIXES:
 
 * Fix an issue when installing the GeoIP2 module on an UBI 7 container where the the `libmaxminddb` package dependency might not be available via `yum` (if it's not available, `libmaxminddb` is installed from an external source).
 * GitHub actions should now correctly skip \*plus\* scenarios only when the NGINX Plus license secrets are not present.
+* Update the versions of the various packages required to build NGINX from source.
 
 TESTS:
 

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -46,9 +46,9 @@ nginx_install_from: nginx_repository
 # Specify source install options for NGINX Open Source.
 # Options represent whether to install from source also or to install from packages (default).
 # These only apply if 'nginx_install_from' is set to 'source'.
-# For the tools, true means we will install from a package and false means install from source.
 # 'nginx_install_source_build_tools' will install compiler and build tools from packages.
-# If false, you need to have these present.
+# If set to false, you need to have these present.
+# For the required libraries, true means we will install from source and false means we will install using the default package manager.
 nginx_install_source_build_tools: true
 nginx_install_source_pcre: false
 nginx_install_source_openssl: true

--- a/molecule/source/converge.yml
+++ b/molecule/source/converge.yml
@@ -10,6 +10,6 @@
         nginx_branch: stable
         nginx_static_modules: [http_ssl_module]
         nginx_install_source_build_tools: true
-        nginx_install_source_pcre: true
-        nginx_install_source_openssl: true
-        nginx_install_source_zlib: true
+        nginx_install_source_pcre: false
+        nginx_install_source_openssl: false
+        nginx_install_source_zlib: false

--- a/tasks/opensource/install-source.yml
+++ b/tasks/opensource/install-source.yml
@@ -358,8 +358,8 @@
     - name: Unpack NGINX
       ansible.builtin.unarchive:
         copy: false
-        dest: /tmp/
         src: "{{ nginx_source.dest }}"
+        dest: /tmp
         mode: 0755
 
     - name: Set static modules

--- a/tasks/opensource/install-source.yml
+++ b/tasks/opensource/install-source.yml
@@ -92,21 +92,21 @@
   block:
     - name: Check for PCRE install
       ansible.builtin.stat:
-        path: /tmp/{{ pcre_version }}
+        path: /tmp/pcre-{{ pcre_version }}
       register: pcre_result
 
     - name: Check for ZLib install
       ansible.builtin.stat:
-        path: /tmp/{{ zlib_version }}
+        path: /tmp/zlib-{{ zlib_version }}
       register: zlib_result
 
     - name: Check for OpenSSL install
       ansible.builtin.stat:
-        path: /tmp/{{ openssl_version }}
+        path: /tmp/openssl-{{ openssl_version }}
       register: openssl_result
 
 - name: Install PCRE dependecy from package
-  when: nginx_install_source_pcre | bool
+  when: not nginx_install_source_pcre | bool
   block:
     - name: (Alpine Linux) Install PCRE dependency from package
       community.general.apk:
@@ -135,40 +135,47 @@
 - name: Install PCRE dependence from source
   when:
     - not pcre_result.stat.exists | bool
-    - not nginx_install_source_pcre | bool
+    - nginx_install_source_pcre | bool
     - not ansible_check_mode | bool
   block:
     - name: Download PCRE dependency
       ansible.builtin.get_url:
-        url: "{{ (pcre_release == 2) | ternary('https://github.com/PCRE2Project/pcre2/releases/download/' ~ pcre_version ~ '/' ~ pcre_version ~ '.tar.gz', 'https://ftp.exim.org/pub/pcre/' ~ pcre_version ~ '.tar.gz') }}"
-        dest: /tmp/{{ pcre_version }}.tar.gz
+        url: "{{ (pcre_release == 2) | ternary('https://github.com/PCRE2Project/pcre2/releases/download/pcre2-' ~ pcre_version ~ '/pcre2-' ~ pcre_version ~ '.tar.gz', 'https://ftp.exim.org/pub/pcre/pcre-' ~ pcre_version ~ '.tar.gz') }}"
+        dest: /tmp
         mode: 0600
       register: pcre_source
+
+    - name: Ensure PCRE directory exists
+      ansible.builtin.file:
+        path: /tmp/pcre-{{ pcre_version }}
+        state: directory
+        mode: 0700
 
     - name: Unpack PCRE dependency
       ansible.builtin.unarchive:
         copy: false
-        dest: /tmp/
         src: "{{ pcre_source.dest }}"
+        dest: /tmp/pcre-{{ pcre_version }}/
         mode: 0700
+        extra_opts: [--strip-components=1]
 
     - name: Configure PCRE dependency
       ansible.builtin.command: ./configure
       args:
-        chdir: /tmp/{{ pcre_version }}
+        chdir: /tmp/pcre-{{ pcre_version }}
         creates: /tmp/makefile
 
     - name: Make PCRE dependency
       community.general.make:
-        chdir: /tmp/{{ pcre_version }}
+        chdir: /tmp/pcre-{{ pcre_version }}
 
     - name: Install PCRE dependency
       community.general.make:
-        chdir: /tmp/{{ pcre_version }}
+        chdir: /tmp/pcre-{{ pcre_version }}
         target: install
 
 - name: Install ZLib dependency from package
-  when: nginx_install_source_zlib | bool
+  when: not nginx_install_source_zlib | bool
   block:
     - name: (Alpine Linux) Install ZLib dependency from package
       community.general.apk:
@@ -197,41 +204,47 @@
 - name: Install ZLib dependency from source
   when:
     - not zlib_result.stat.exists | bool
-    - not nginx_install_source_zlib | bool
+    - nginx_install_source_zlib | bool
     - not ansible_check_mode | bool
   block:
     - name: Download ZLib dependency
       ansible.builtin.get_url:
-        url: https://zlib.net/{{ zlib_version }}.tar.gz
-        dest: /tmp/{{ zlib_version }}.tar.gz
+        url: https://github.com/madler/zlib/releases/download/v{{ zlib_version }}/zlib-{{ zlib_version }}.tar.gz
+        dest: /tmp
         mode: 0600
       register: zlib_source
+
+    - name: Ensure ZLib directory exists
+      ansible.builtin.file:
+        path: /tmp/zlib-{{ zlib_version }}
+        state: directory
+        mode: 0700
 
     - name: Unpack ZLib dependency
       ansible.builtin.unarchive:
         copy: false
-        dest: /tmp/
         src: "{{ zlib_source.dest }}"
+        dest: /tmp/zlib-{{ zlib_version }}
         mode: 0700
+        extra_opts: [--strip-components=1]
 
     - name: Configure ZLib dependency
       ansible.builtin.command: ./configure
       args:
-        chdir: /tmp/{{ zlib_version }}
+        chdir: /tmp/zlib-{{ zlib_version }}
         creates: /tmp/makefile
 
     - name: Make ZLib dependency
       community.general.make:
-        chdir: /tmp/{{ zlib_version }}
+        chdir: /tmp/zlib-{{ zlib_version }}
 
     - name: Install ZLib dependency
       community.general.make:
-        chdir: /tmp/{{ zlib_version }}
+        chdir: /tmp/zlib-{{ zlib_version }}
         target: install
 
-
 - name: Install OpenSSL dependency from package
-  when: nginx_install_source_openssl | bool
+  when: not nginx_install_source_openssl | bool
   block:
     - name: (Alpine Linux) Install OpenSSL dependency from package
       community.general.apk:
@@ -260,36 +273,43 @@
 - name: Install OpenSSL dependency from source
   when:
     - not openssl_result.stat.exists | bool
-    - not nginx_install_source_openssl | bool
+    - nginx_install_source_openssl | bool
     - not ansible_check_mode | bool
   block:
     - name: Download OpenSSL dependency
       ansible.builtin.get_url:
-        url: https://www.openssl.org/source/{{ openssl_version }}.tar.gz
+        url: https://github.com/openssl/openssl/archive/refs/tags/openssl-{{ openssl_version }}.tar.gz
         dest: /tmp/{{ openssl_version }}.tar.gz
         mode: 0600
       register: openssl_source
 
+    - name: Ensure OpenSSL directory exists
+      ansible.builtin.file:
+        path: /tmp/openssl-{{ openssl_version }}
+        state: directory
+        mode: 0700
+
     - name: Unpack OpenSSL dependency
       ansible.builtin.unarchive:
         copy: false
-        dest: /tmp/
         src: "{{ openssl_source.dest }}"
+        dest: /tmp/openssl-{{ openssl_version }}
         mode: 0700
+        extra_opts: [--strip-components=1]
 
     - name: Configure OpenSSL dependency
       ansible.builtin.command: ./config --prefix=/usr/local/openssl --openssldir=/usr/local/openssl shared zlib
       args:
-        chdir: /tmp/{{ openssl_version }}
+        chdir: /tmp/openssl-{{ openssl_version }}
         creates: /tmp/makefile
 
     - name: Make OpenSSL dependency
       community.general.make:
-        chdir: /tmp/{{ openssl_version }}
+        chdir: /tmp/openssl-{{ openssl_version }}
 
     - name: Install OpenSSL dependency
       community.general.make:
-        chdir: /tmp/{{ openssl_version }}
+        chdir: /tmp/openssl-{{ openssl_version }}
         target: install
 
 - name: Get NGINX version
@@ -360,9 +380,9 @@
         --user=nginx
         --with-mail=dynamic
         --with-stream
-        {{ nginx_install_source_pcre | ternary('', '--with-pcre=../' + pcre_version) }}
-        {{ nginx_install_source_zlib | ternary('', '--with-zlib=../' + zlib_version) }}
-        {{ nginx_install_source_openssl | ternary('', '--with-openssl=../' + openssl_version) }}
+        {{ nginx_install_source_pcre | ternary('--with-pcre=../pcre-' + pcre_version | string, '') }}
+        {{ nginx_install_source_zlib | ternary('--with-zlib=../zlib-' + zlib_version | string, '') }}
+        {{ nginx_install_source_openssl | ternary('--with-openssl=../openssl-' + openssl_version | string, '') }}
         {{ nginx_install_source_static_modules | default('') }}
       args:
         chdir: /tmp/{{ nginx_version }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -74,9 +74,9 @@ nginx_freebsd_dependencies: [
 # Default locations and versions when 'nginx_install_from' is set to 'source'.
 # Set 'pcre_release' to 1 to install PCRE 1, modify the 'openssl_version' to move back to 1.1.1.
 pcre_release: 2
-pcre_version: pcre2-10.40
-zlib_version: zlib-1.2.12
-openssl_version: openssl-3.0.5
+pcre_version: 10.42
+zlib_version: 1.2.13
+openssl_version: 3.0.7
 
 # Supported NGINX Open Source dynamic modules
 nginx_modules_list: [


### PR DESCRIPTION
### Proposed changes

BREAKING CHANGES:

* When building from source the various libraries required to build NGINX from source, you will no longer need to specify the name of the package, only the version:

  ```yaml
  pcre_version: pcre2-10.42
  ```

  is now:

  ```yaml
  pcre_version: 10.42
  ```

* The `nginx_install_source_<package>: false` parameters have been reversed. Setting `nginx_install_source_pcre: true` will now build PCRE from source, instead of using the default package manager. The previous behavior was unintuitive at best.

ENHANCEMENTS:

Use the official GitHub repositories as the source for the various packages required to compile NGINX OSS from source.

BUG FIXES:

Update the versions of the various packages required to build NGINX from source. The version of `zlib` listed in the role was no longer available. (Fixes #555.)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
