### PR TITLE
Update Molecule platform data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ BUG FIXES:
 TESTS:
 
 * Update GitHub actions to run on Ubuntu 22.04 (and thus support `cgroups` v2).
-* Explicitly specify `amd64` as the platform used in the Amazon Linux 2/CentOS/Oracle Linux/RHEL 7/SLES 15 Molecule Docker images. This will ensure that tests work when run on different host architectures (e.g. newer Macbooks with `arm64` processors) when running tests in distributions that only support `amd64` (either due to lack of support for `cgroups` v2 or due to lack of builds for `arm64`).
+* Explicitly specify `amd64` as the platform used in the Amazon Linux 2/CentOS/Oracle Linux/RHEL 7/SLES 15 Molecule Docker images. This will ensure that tests work when run on different host architectures (e.g. newer Macbooks with `arm64` processors) when running tests in distributions that only support `amd64` (either due to lack of support for a `cgroups` v2 backport or due to lack of builds for `arm64`).
 
 ## 0.23.2 (September 28, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ BUG FIXES:
 TESTS:
 
 * Update GitHub actions to run on Ubuntu 22.04 (and thus support `cgroups` v2).
-* Explicitly specify `amd64` as the platform used in RHEL 7 Molecule Docker images. This will ensure that tests work when run on different host architectures (e.g. newer Macbooks with `arm` processors) given the RHEL 7 UBI image only supports `amd64`.
+* Explicitly specify `amd64` as the platform used in the Amazon Linux 2/CentOS/Oracle Linux/RHEL 7/SLES 15 Molecule Docker images. This will ensure that tests work when run on different host architectures (e.g. newer Macbooks with `arm64` processors) when running tests in distributions that only support `amd64` (either due to lack of support for `cgroups` v2 or due to lack of builds for `arm64`).
 
 ## 0.23.2 (September 28, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ BUG FIXES:
 TESTS:
 
 * Update GitHub actions to run on Ubuntu 22.04 (and thus support `cgroups` v2).
-* Explicitly specify `amd64` as the platform used in Molecule tests. This will ensure that tests work as expected when run on different host architectures (e.g. newer Macbooks with `arm` processors).
+* Explicitly specify `amd64` as the platform used in RHEL 7 Molecule Docker images. This will ensure that tests work when run on different host architectures (e.g. newer Macbooks with `arm` processors) given the RHEL 7 UBI image only supports `amd64`.
 
 ## 0.23.2 (September 28, 2022)
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,6 @@ lint: |
 platforms:
   - name: almalinux-8
     image: almalinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -16,7 +15,6 @@ platforms:
     command: /usr/sbin/init
   - name: almalinux-9
     image: almalinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -25,7 +23,6 @@ platforms:
     command: /usr/sbin/init
   - name: alpine-3.14
     image: alpine:3.14
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -34,7 +31,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -43,7 +39,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -52,7 +47,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -79,7 +73,6 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -97,7 +90,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +98,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -124,7 +115,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -133,7 +123,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -142,7 +131,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-8
     image: rockylinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -151,7 +139,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -169,7 +156,6 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -178,7 +164,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -187,7 +172,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -7,7 +7,6 @@ lint: |
 platforms:
   - name: almalinux-8
     image: almalinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -16,7 +15,6 @@ platforms:
     command: /usr/sbin/init
   - name: almalinux-9
     image: almalinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -25,7 +23,6 @@ platforms:
     command: /usr/sbin/init
   - name: alpine-3.14
     image: alpine:3.14
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -34,7 +31,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -43,7 +39,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -52,7 +47,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -79,7 +73,6 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -97,7 +90,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +98,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -124,7 +115,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -133,7 +123,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -142,7 +131,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-8
     image: rockylinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -151,7 +139,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -169,7 +156,6 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -178,7 +164,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -187,7 +172,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/downgrade_plus/molecule.yml
+++ b/molecule/downgrade_plus/molecule.yml
@@ -7,7 +7,6 @@ lint: |
 platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
   - name: almalinux-8
     image: almalinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -16,16 +15,22 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: almalinux-9
     image: almalinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
+  - name: alpine-3.13
+    image: alpine:3.13
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: alpine-3.14
     image: alpine:3.14
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -34,7 +39,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -43,7 +47,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -70,7 +73,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +90,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -97,7 +98,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -115,7 +115,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -124,7 +123,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -133,7 +131,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rockylinux-8
     image: rockylinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -142,7 +139,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -160,7 +156,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -169,7 +164,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -178,7 +172,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/module/molecule.yml
+++ b/molecule/module/molecule.yml
@@ -7,7 +7,6 @@ lint: |
 platforms:
   - name: almalinux-8
     image: almalinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -16,7 +15,6 @@ platforms:
     command: /usr/sbin/init
   - name: almalinux-9
     image: almalinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -25,7 +23,6 @@ platforms:
     command: /usr/sbin/init
   - name: alpine-3.14
     image: alpine:3.14
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -34,7 +31,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -43,7 +39,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -52,7 +47,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -79,7 +73,6 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -97,7 +90,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +98,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -124,7 +115,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -133,7 +123,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -142,7 +131,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-8
     image: rockylinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -151,7 +139,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -169,7 +156,6 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -178,7 +164,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -187,7 +172,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -7,7 +7,6 @@ lint: |
 platforms:
   - name: almalinux-8
     image: almalinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -16,16 +15,22 @@ platforms:
     command: /usr/sbin/init
   - name: almalinux-9
     image: almalinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
+  - name: alpine-3.13
+    image: alpine:3.13
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: alpine-3.14
     image: alpine:3.14
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -34,7 +39,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -43,7 +47,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -52,7 +55,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +90,6 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -97,7 +98,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +106,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -124,7 +123,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -133,7 +131,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -142,7 +139,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-8
     image: rockylinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -151,7 +147,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -169,7 +164,6 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -178,7 +172,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -187,7 +180,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -81,7 +81,6 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -90,6 +89,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -7,7 +7,6 @@ lint: |
 platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions for some undetermined reason
   - name: almalinux-8
     image: almalinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -16,7 +15,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: almalinux-9
     image: almalinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -25,7 +23,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: alpine-3.14
     image: alpine:3.14
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -34,7 +31,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -43,7 +39,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -52,7 +47,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -79,7 +73,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +81,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -97,7 +89,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +97,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: rockylinux-8
     image: rockylinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -115,7 +105,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -133,7 +122,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -142,7 +130,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -150,7 +137,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-8
-    platform: amd64
     image: rockylinux:8
     dockerfile: ../common/Dockerfile.j2
     privileged: true
@@ -160,7 +146,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -178,7 +163,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -187,7 +171,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -196,7 +179,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -7,7 +7,6 @@ lint: |
 platforms:
   - name: almalinux-8
     image: almalinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -16,7 +15,6 @@ platforms:
     command: /usr/sbin/init
   - name: almalinux-9
     image: almalinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -25,7 +23,6 @@ platforms:
     command: /usr/sbin/init
   - name: alpine-3.14
     image: alpine:3.14
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -34,7 +31,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -43,7 +39,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -52,7 +47,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -79,7 +73,6 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -97,7 +90,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +98,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -124,7 +115,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -133,7 +123,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -142,7 +131,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-8
     image: rockylinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -151,7 +139,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -169,7 +156,6 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -178,7 +164,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -187,7 +172,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall_plus/molecule.yml
+++ b/molecule/uninstall_plus/molecule.yml
@@ -7,7 +7,6 @@ lint: |
 platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible core 2.13
   - name: almalinux-8
     image: almalinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -16,7 +15,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: almalinux-9
     image: almalinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -25,7 +23,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: alpine-3.13
     image: alpine:3.13
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -34,7 +31,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: alpine-3.14
     image: alpine:3.14
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -43,7 +39,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -52,7 +47,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -61,7 +55,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +81,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +98,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -115,7 +106,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -133,7 +123,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -142,7 +131,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -151,7 +139,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: rockylinux-8
     image: rockylinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -160,7 +147,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -178,7 +164,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -187,7 +172,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -7,7 +7,6 @@ lint: |
 platforms:
   - name: almalinux-8
     image: almalinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -16,7 +15,6 @@ platforms:
     command: /usr/sbin/init
   - name: almalinux-9
     image: almalinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -25,7 +23,6 @@ platforms:
     command: /usr/sbin/init
   - name: alpine-3.14
     image: alpine:3.14
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -34,7 +31,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -43,7 +39,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -52,7 +47,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -79,7 +73,6 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -97,7 +90,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +98,6 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -124,7 +115,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -133,7 +123,6 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -142,7 +131,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-8
     image: rockylinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -151,7 +139,6 @@ platforms:
     command: /usr/sbin/init
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -169,7 +156,6 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -178,7 +164,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -187,7 +172,6 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade_plus/molecule.yml
+++ b/molecule/upgrade_plus/molecule.yml
@@ -7,7 +7,6 @@ lint: |
 platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the moment) so it's impossible to test the upgrade scenario
   - name: almalinux-8
     image: almalinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -16,16 +15,22 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: almalinux-9
     image: almalinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
+  - name: alpine-3.13
+    image: alpine:3.13
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: alpine-3.14
     image: alpine:3.14
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -34,7 +39,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -43,7 +47,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -52,7 +55,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -70,7 +72,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +89,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -97,7 +97,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -115,7 +114,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -124,7 +122,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -133,7 +130,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rockylinux-8
     image: rockylinux:8
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -142,7 +138,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rockylinux-9
     image: rockylinux:9.0.20220720
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -160,7 +155,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -169,7 +163,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -178,7 +171,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade_plus/molecule.yml
+++ b/molecule/upgrade_plus/molecule.yml
@@ -55,6 +55,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
+    platform: amd64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host


### PR DESCRIPTION
### Proposed changes

**Note:** This PR partially reverts the changes made in #572.

Explicitly specify `amd64` as the platform used in the Amazon Linux 2/CentOS/Oracle Linux/RHEL 7/SLES 15 Molecule Docker images. This will ensure that tests work when run on different host architectures (e.g. newer Macbooks with `arm64` processors) when running tests in distributions that only support `amd64` (either due to lack of support for a `cgroups` v2 backport or due to lack of builds for `arm64`).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
