### PR TITLE
Replace non-existent GitHub actions key

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # Main global owner #
 #####################
-
 * @alessfg
 /.github/workflows/
 *.md

--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -1,6 +1,6 @@
 ---
 name: Ansible Galaxy import
-"on":
+on:
   release:
     types:
       - published

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,14 +1,14 @@
 ---
 name: Molecule CI/CD
-"on":
+on:
   pull_request:
     branches:
       - main
   push:
     branches:
       - main
-    ignore-tags:
-      - "*"
+    tags-ignore:
+      - "**"
   schedule:
     - cron: "0 0 1 * *"
   workflow_dispatch:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,6 +1,6 @@
 ---
 name: Release Drafter
-"on":
+on:
   pull_request:
     types:
       - opened

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ BUG FIXES:
 * Fix an issue when installing the GeoIP2 module on an UBI 7 container where the the `libmaxminddb` package dependency might not be available via `yum` (if it's not available, `libmaxminddb` is installed from an external source).
 * GitHub actions should now correctly skip \*plus\* scenarios only when the NGINX Plus license secrets are not present.
 * Update the versions of the various packages required to build NGINX from source. The version of `zlib` listed in the role was no longer available.
+* The `ignore-tags` GitHub actions key does not exist. Replace it with the correct key, `tags-ignore`.
 
 TESTS:
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ If you wish to install NGINX Plus using this role, you will need to obtain an NG
 * Instructions on how to install Molecule can be found in the [Molecule website](https://molecule.readthedocs.io/en/latest/installation.html). *You will also need to install the Molecule Docker driver.*
 * To run the NGINX Plus Molecule tests, you must copy your NGINX Plus license to the role's [`files/license`](https://github.com/nginxinc/ansible-role-nginx/blob/main/files/license/) folder.
 
-You can alternatively add your NGINX Plus repository certificate and key to the local environment. Run the following commands to export these files as base64-encoded variables and execute the Molecule tests:
+  You can alternatively add your NGINX Plus repository certificate and key to the local environment. Run the following commands to export these files as base64-encoded variables and execute the Molecule tests:
 
-```bash
-export NGINX_CRT=$( cat <path to your certificate file> | base64 )
-export NGINX_KEY=$( cat <path to your key file> | base64 )
-molecule test -s plus
-```
+  ```bash
+  export NGINX_CRT=$( cat <path to your certificate file> | base64 )
+  export NGINX_KEY=$( cat <path to your key file> | base64 )
+  molecule test -s plus
+  ```
 
 ## Installation
 


### PR DESCRIPTION
### Proposed changes

The `ignore-tags` GitHub actions key does not exist. Replace it with the correct key, `tags-ignore`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
