### PR TITLE
Add s390x as a platform for Molecule tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ TESTS:
 
 * Update GitHub actions to run on Ubuntu 22.04 (and thus support `cgroups` v2).
 * Explicitly specify `x86_64`/`amd64` as the platform used in the Amazon Linux 2/CentOS/Oracle Linux/RHEL 7/SLES 15 Molecule Docker images. This will ensure that tests work when run on different host architectures (e.g. newer Macbooks with `aarch64`/`arm64` processors) when running tests in distributions that only support `x86_64` (either due to lack of support for a `cgroups` v2 backport or due to lack of builds for `aarch64`).
-* Test some distributions using `aarch64` and `s390x` architectures. This should ensure the role works as intended across the various architectures that are officially supported.
+* Explicitly test some distributions using `aarch64` and `s390x` as the Molecule platform. This should ensure the role works as intended across the various architectures that are officially supported.
 
 ## 0.23.2 (September 28, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,13 @@ BUG FIXES:
 * GitHub actions should now correctly skip \*plus\* scenarios only when the NGINX Plus license secrets are not present.
 * Update the versions of the various packages required to build NGINX from source. The version of `zlib` listed in the role was no longer available.
 * The `ignore-tags` GitHub actions key does not exist. Replace it with the correct key, `tags-ignore`.
+* Remove the `arch` option from the Debian family NGINX repository source. In its current form this prevented the role from working any platforms beyond `x86_64`/`amd64` and `aarch64`/`arm64`.
 
 TESTS:
 
 * Update GitHub actions to run on Ubuntu 22.04 (and thus support `cgroups` v2).
-* Explicitly specify `amd64` as the platform used in the Amazon Linux 2/CentOS/Oracle Linux/RHEL 7/SLES 15 Molecule Docker images. This will ensure that tests work when run on different host architectures (e.g. newer Macbooks with `arm64` processors) when running tests in distributions that only support `amd64` (either due to lack of support for a `cgroups` v2 backport or due to lack of builds for `arm64`).
+* Explicitly specify `x86_64`/`amd64` as the platform used in the Amazon Linux 2/CentOS/Oracle Linux/RHEL 7/SLES 15 Molecule Docker images. This will ensure that tests work when run on different host architectures (e.g. newer Macbooks with `aarch64`/`arm64` processors) when running tests in distributions that only support `x86_64` (either due to lack of support for a `cgroups` v2 backport or due to lack of builds for `aarch64`).
+* Test some distributions using `aarch64` and `s390x` architectures. This should ensure the role works as intended across the various architectures that are officially supported.
 
 ## 0.23.2 (September 28, 2022)
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -39,6 +39,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -47,6 +48,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,7 +57,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -64,7 +66,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -81,7 +83,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +108,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -115,6 +117,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -123,6 +126,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +151,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,6 +160,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -164,6 +169,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -172,6 +178,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -39,6 +39,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -47,6 +48,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,7 +57,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -64,7 +66,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -81,7 +83,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +108,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -115,6 +117,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -123,6 +126,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +151,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,6 +160,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -164,6 +169,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -172,6 +178,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/downgrade_plus/molecule.yml
+++ b/molecule/downgrade_plus/molecule.yml
@@ -47,6 +47,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,7 +56,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -64,7 +65,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -81,7 +82,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +107,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -115,6 +116,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -123,6 +125,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +150,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,6 +159,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -164,6 +168,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -172,6 +177,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/module/molecule.yml
+++ b/molecule/module/molecule.yml
@@ -39,6 +39,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -47,6 +48,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,7 +57,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -64,7 +66,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -81,7 +83,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +108,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -115,6 +117,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -123,6 +126,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +151,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,6 +160,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -164,6 +169,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -172,6 +178,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -47,6 +47,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,6 +56,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +65,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -72,7 +74,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -89,7 +91,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -114,7 +116,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -123,6 +125,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -131,6 +134,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -155,7 +159,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -164,6 +168,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -172,6 +177,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -180,6 +186,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -39,6 +39,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -47,6 +48,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,7 +57,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -64,7 +66,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -95,25 +97,9 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: rockylinux-8
-    image: rockylinux:8
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
-  - name: rockylinux-9
-    image: rockylinux:9.0.20220720
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
   - name: rhel-7
-    image: registry.access.redhat.com/ubi7/ubi:7.9
-    platform: amd64
+    image: registry.access.redhat.com/ubi7:7.9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -122,6 +108,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -130,6 +117,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -154,7 +142,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -163,6 +151,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -171,6 +160,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -179,6 +169,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -39,6 +39,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -47,6 +48,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,7 +57,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -64,7 +66,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -81,7 +83,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -105,8 +107,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-7
-    image: registry.access.redhat.com/ubi7/ubi:7.9
-    platform: amd64
+    image: registry.access.redhat.com/ubi7:7.9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -115,6 +117,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -123,6 +126,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +151,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,6 +160,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -164,6 +169,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -172,6 +178,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall_plus/molecule.yml
+++ b/molecule/uninstall_plus/molecule.yml
@@ -47,6 +47,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,6 +56,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +65,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -72,7 +74,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -89,7 +91,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -113,8 +115,8 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-7
-    image: registry.access.redhat.com/ubi7/ubi:7.9
-    platform: amd64
+    image: registry.access.redhat.com/ubi7:7.9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -123,6 +125,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -131,6 +134,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -155,7 +159,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -164,6 +168,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -172,6 +177,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -39,6 +39,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -47,6 +48,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,7 +57,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -64,7 +66,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -81,7 +83,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +108,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -115,6 +117,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -123,6 +126,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +151,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,6 +160,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -164,6 +169,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -172,6 +178,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade_plus/molecule.yml
+++ b/molecule/upgrade_plus/molecule.yml
@@ -47,6 +47,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -55,7 +56,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -64,7 +65,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -81,7 +82,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -106,7 +107,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -115,6 +116,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -123,6 +125,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +150,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: amd64
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,6 +159,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -164,6 +168,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -172,6 +177,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -33,7 +33,7 @@ nginx_default_signing_key_rsa_pub: https://nginx.org/keys/nginx_signing.rsa.pub
 nginx_default_repository_alpine: "@nginx http://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}alpine/v{{ ansible_facts['distribution_version'] | regex_search('^[0-9]+\\.[0-9]+') }}/main"
 nginx_default_repository_amazon: https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}/amzn2/$releasever/$basearch
 nginx_default_repository_debian:
-  - deb [arch={{ (ansible_facts['architecture'] == 'aarch64') | ternary('arm64', 'amd64') }} signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}{{ ansible_facts['distribution'] | lower }}/ {{ ansible_facts['distribution_release'] }} nginx
+  - deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}{{ ansible_facts['distribution'] | lower }}/ {{ ansible_facts['distribution_release'] }} nginx
   - deb-src [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}{{ ansible_facts['distribution'] | lower }}/ {{ ansible_facts['distribution_release'] }} nginx
 nginx_default_repository_redhat: https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}{{ (ansible_facts['distribution'] == 'CentOS') | ternary('centos', 'rhel') }}/{{ ansible_facts['distribution_major_version'] }}/$basearch/
 nginx_default_repository_suse: https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}sles/{{ ansible_facts['distribution_major_version'] }}
@@ -41,7 +41,7 @@ nginx_default_repository_suse: https://nginx.org/packages/{{ (nginx_branch == 'm
 # Default NGINX Plus repositories
 nginx_plus_default_repository_alpine: https://pkgs.nginx.com/plus/alpine/v{{ ansible_facts['distribution_version'] | regex_search('^[0-9]+\.[0-9]+') }}/main
 nginx_plus_default_repository_amazon: https://pkgs.nginx.com/plus/amzn{{ (ansible_facts['distribution_major_version'] is version('2', '==')) | ternary('2', '') }}/$releasever/$basearch
-nginx_plus_default_repository_debian: deb [arch={{ (ansible_facts['architecture'] == 'aarch64') | ternary('arm64', 'amd64') }} signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] }} nginx-plus
+nginx_plus_default_repository_debian: deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] }} nginx-plus
 nginx_plus_default_repository_freebsd: https://pkgs.nginx.com/plus/freebsd/${ABI}/latest
 nginx_plus_default_repository_redhat: https://pkgs.nginx.com/plus/{{ (ansible_facts['distribution'] == 'CentOS') | ternary('centos', 'rhel') }}/{{ (ansible_facts['distribution_version'] is version('7.4', '>=') and ansible_facts['distribution_version'] is version('8', '<')) | ternary('7.4', ansible_facts['distribution_major_version']) }}/$basearch/
 nginx_plus_default_repository_suse: https://pkgs.nginx.com/plus/sles/{{ ansible_facts['distribution_major_version'] }}?ssl_clientcert=/etc/ssl/nginx/nginx-repo-bundle.crt&ssl_verify=peer


### PR DESCRIPTION
### Proposed changes

BUG FIXES:

Remove the `arch` option from the Debian family NGINX repository source. In its current form this prevented the role from working any platforms beyond `x86_64`/`amd64` and `aarch64`/`arm64`.

TESTS:

Explicitly test some distributions using `aarch64` and `s390x` as the Molecule platform. This should ensure the role works as intended across the various architectures that are officially supported.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
