### PR TITLE
Install 'cryptography' using 'pip' Instead of Using System's Package Manager

### DIFF
--- a/tasks/plus/install-pip-2.yml
+++ b/tasks/plus/install-pip-2.yml
@@ -1,0 +1,17 @@
+- name: (Python 2) Get version 2.7 'pip' script
+  ansible.builtin.get_url:
+    url: "https://bootstrap.pypa.io/pip/2.7/get-pip.py"
+    dest: "/tmp/get-pip.py"
+    mode: 0755
+
+- name: (Python 2) Check if 'pip' binary exists
+  ansible.builtin.stat:
+    path: /usr/bin/pip
+  ignore_errors: true
+  register: pip
+
+- name: (Python 2) Install 'pip' version 2.7
+  ansible.builtin.command: "python get-pip.py"
+  args:
+    chdir: /tmp/
+  when: not pip.stat.exists

--- a/tasks/plus/install-pip-3.yml
+++ b/tasks/plus/install-pip-3.yml
@@ -1,0 +1,7 @@
+- name: (Python 3) Install 'pip' package
+  ansible.builtin.package:
+    name: python3-pip
+
+- name: (Python 3) Ensure 'pip' is updated
+  ansible.builtin.pip:
+    name: pip>=21.2.4

--- a/tasks/plus/setup-license.yml
+++ b/tasks/plus/setup-license.yml
@@ -47,6 +47,9 @@
 - name: (Debian/Red Hat/SLES OSs) Set up NGINX Plus license
   when: ansible_facts['os_family'] != 'Alpine'
   block:
+    - name: (RedHat) Install pip
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/plus/install-pip-{{ ansible_python['version']['major'] }}.yml"
+
     - name: (Debian/Red Hat/SLES OSs) Create SSL directory
       ansible.builtin.file:
         path: /etc/ssl/nginx
@@ -64,8 +67,8 @@
         - "{{ nginx_license['key'] }}"
 
     - name: (Debian/Red Hat/SLES OSs) Install cryptography package
-      ansible.builtin.package:
-        name: "{{ (ansible_python['version']['major'] == 3) | ternary('python3-cryptography', 'python2-cryptography') }}"
+      ansible.builtin.pip:
+        name: cryptography
 
     - name: (Debian/Red Hat/SLES OSs) Check that NGINX Plus certificate is valid
       community.crypto.x509_certificate_info:


### PR DESCRIPTION
### Proposed changes

The **cryptography** package was installed using the OS's repo package manager. This PR will change from using the system's package manager to **pip**.

This is to resolve an error when running this role using *Amazon Linux 2 (AL2)*. The python interpreter uses python2 in container tests but python3 on AL2 deployed in AWS. This role tries to install **python3-cryptography** which does not exists.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
