### PR TITLE
Enable SELinux config with Oracle Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ENHANCEMENTS:
 
-Refactor the OSS BSD installation process to consolidate tasks and avoid Ansible Lint warnings.
+- Refactor the OSS BSD installation process to consolidate tasks and avoid Ansible Lint warnings.
+- Enable SELinux configuration tasks on Oracle Linux OS.
 
 ## 0.24.0 (January 29, 2023)
 

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -30,4 +30,4 @@
         chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
       changed_when: false
       register: version
-      failed_when: version is not search('1.23.3')
+      failed_when: version is not search('1.23.4')

--- a/tasks/prerequisites/prerequisites.yml
+++ b/tasks/prerequisites/prerequisites.yml
@@ -7,7 +7,7 @@
     - nginx_selinux | bool
     - "'selinux' in ansible_facts"
     - ansible_facts['os_family'] in ['RedHat', 'Suse']
-    - ansible_facts['distribution'] not in ['Amazon', 'OracleLinux']
+    - ansible_facts['distribution'] != 'Amazon'
   block:
     - name: Check if SELinux is enabled
       ansible.builtin.debug:


### PR DESCRIPTION
### Proposed changes

We installed Oracle Linux on our VMWare Cluster. We noticed the SELinux configuration is like any other rhel OS so would like to enable ability to configure this by setting the nginx_selinux variable in this role.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
