### PR TITLE
Extract Ansible Lint into its own GH actions job

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 jobs:
   ansible-lint:
-    name: Linter
+    name: Ansible Lint
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the codebase

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -13,6 +13,23 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 jobs:
+  lint:
+    name: Linter
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Install Ansible Lint
+        run: pip3 install ansible-lint
+
+      - name: Run Ansible Lint
+        run: ansible-lint
   molecule:
     name: Molecule
     runs-on: ubuntu-22.04
@@ -35,6 +52,7 @@ jobs:
           - upgrade
           - upgrade-plus
           - version
+    needs: lint
     steps:
       - name: Check out the codebase
         if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -13,7 +13,7 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 jobs:
-  lint:
+  ansible-lint:
     name: Linter
     runs-on: ubuntu-22.04
     steps:
@@ -26,13 +26,13 @@ jobs:
           python-version: 3.x
 
       - name: Install Ansible Lint
-        run: pip3 install ansible-core ansible-lint
+        run: pip3 install -r .github/workflows/requirements/requirements_ansible_lint.txt
 
       - name: Install Ansible collection dependencies
         run: ansible-galaxy install -r .github/workflows/requirements/requirements_ansible.yml
 
       - name: Run Ansible Lint
-        run: ansible-lint
+        run: ansible-lint --force-color
 
   molecule:
     name: Molecule
@@ -56,7 +56,7 @@ jobs:
           - upgrade
           - upgrade-plus
           - version
-    needs: lint
+    needs: ansible-lint
     steps:
       - name: Check out the codebase
         if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -26,10 +26,14 @@ jobs:
           python-version: 3.x
 
       - name: Install Ansible Lint
-        run: pip3 install ansible-lint
+        run: pip3 install ansible-core ansible-lint
+
+      - name: Install Ansible collection dependencies
+        run: ansible-galaxy install -r .github/workflows/requirements/requirements_ansible.yml
 
       - name: Run Ansible Lint
         run: ansible-lint
+
   molecule:
     name: Molecule
     runs-on: ubuntu-22.04
@@ -74,7 +78,7 @@ jobs:
         if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         run: pip3 install -r .github/workflows/requirements/requirements_molecule.txt
 
-      - name: Install Ansible core dependencies
+      - name: Install Ansible collection dependencies
         if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         run: ansible-galaxy install -r .github/workflows/requirements/requirements_ansible.yml
 

--- a/.github/workflows/requirements/requirements_ansible_lint.txt
+++ b/.github/workflows/requirements/requirements_ansible_lint.txt
@@ -1,0 +1,2 @@
+ansible-core==2.14.4
+ansible-lint==6.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ ENHANCEMENTS:
 
 CI/CD:
 
+- Split Ansible Lint into its own GH actions job since Molecule no longer runs linters natively.
 - Replace `molecule[docker]` with `molecule` and `molecule-plugins[docker]`.
 - Explicitly set the `ansible-compat` version.
 - Add pre-releases to Release Drafter.

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms:
   - name: almalinux-8
     image: almalinux:8

--- a/molecule/distribution/molecule.yml
+++ b/molecule/distribution/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when installing NGINX from EPEL. The role works as expected when targeting a RHEL 7 VM instead.
   - name: almalinux-8
     image: almalinux:8

--- a/molecule/downgrade-plus/molecule.yml
+++ b/molecule/downgrade-plus/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
   - name: almalinux-8
     image: almalinux:8

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms:
   - name: almalinux-8
     image: almalinux:8

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms:
   - name: almalinux-8
     image: almalinux:8

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions for some undetermined reason
   - name: almalinux-8
     image: almalinux:8

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms:
   - name: almalinux-8
     image: almalinux:8

--- a/molecule/uninstall-plus/molecule.yml
+++ b/molecule/uninstall-plus/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible core 2.13
   - name: almalinux-8
     image: almalinux:8

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms:
   - name: almalinux-8
     image: almalinux:8

--- a/molecule/upgrade-plus/molecule.yml
+++ b/molecule/upgrade-plus/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the moment) so it's impossible to test the upgrade scenario
   - name: almalinux-8
     image: almalinux:8

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms:
   - name: almalinux-8
     image: almalinux:8

--- a/molecule/version/molecule.yml
+++ b/molecule/version/molecule.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  ansible-lint --force-color
 platforms:
   - name: almalinux-8
     image: almalinux:8


### PR DESCRIPTION
### Proposed changes

Split Ansible Lint into its own GH actions job since Molecule no longer runs linters natively.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
