### PR TITLE
fix: OracleLinux 8 uses python3.11 cryptography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ ENHANCEMENTS:
 - Refactor handlers to avoid Ansible Lint warnings.
 - Enable SELinux configuration tasks on Oracle Linux OS.
 - Bump the Ansible `ansible.posix` collection to `1.5.2`, `community.general` collection to `6.4.0`, `community.crypto` collection to `2.13.0` and `community.docker` collection to `3.4.5`.
+- Oracle Linux 8 requires python library package `python3.11-cryptography` for validating the NGINX Plus repository certificate.
 
 CI/CD:
 

--- a/tasks/plus/setup-license.yml
+++ b/tasks/plus/setup-license.yml
@@ -66,8 +66,10 @@
     - name: (Debian/Red Hat/SLES OSs) Install cryptography package
       ansible.builtin.package:
         name: "{{ (ansible_python['version']['major'] == 3) | ternary('python3-cryptography', 'python2-cryptography') }}"
-      when: (ansible_facts['distribution'] != "OracleLinux" and ansible_facts['distribution_major_version'] != "8")
-
+      when:        
+        - ansible_facts['distribution'] != "OracleLinux"
+        - ansible_facts['distribution_major_version'] != "8"
+        
     - name: (OracleLinux 8) Install cryptography package
       ansible.builtin.package:
         name: "python3.11-cryptography"

--- a/tasks/plus/setup-license.yml
+++ b/tasks/plus/setup-license.yml
@@ -66,6 +66,14 @@
     - name: (Debian/Red Hat/SLES OSs) Install cryptography package
       ansible.builtin.package:
         name: "{{ (ansible_python['version']['major'] == 3) | ternary('python3-cryptography', 'python2-cryptography') }}"
+      when: (ansible_facts['distribution'] != "OracleLinux" and ansible_facts['distribution_major_version'] != "8")
+
+    - name: (OracleLinux 8) Install cryptography package
+      ansible.builtin.package:
+        name: "python3.11-cryptography"
+      when:
+        - ansible_facts['distribution'] == "OracleLinux"
+        - ansible_facts['distribution_major_version'] == "8"
 
     - name: (Debian/Red Hat/SLES OSs) Check that NGINX Plus certificate is valid
       community.crypto.x509_certificate_info:

--- a/tasks/plus/setup-license.yml
+++ b/tasks/plus/setup-license.yml
@@ -66,10 +66,10 @@
     - name: (Debian/Red Hat/SLES OSs) Install cryptography package
       ansible.builtin.package:
         name: "{{ (ansible_python['version']['major'] == 3) | ternary('python3-cryptography', 'python2-cryptography') }}"
-      when:        
+      when:
         - ansible_facts['distribution'] != "OracleLinux"
         - ansible_facts['distribution_major_version'] != "8"
-        
+
     - name: (OracleLinux 8) Install cryptography package
       ansible.builtin.package:
         name: "python3.11-cryptography"


### PR DESCRIPTION
### Proposed changes

NGINX Plus was failing to install on OracleLinux 8 due to a mismatch in python3 versions for the cryptography package

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
