### PR TITLE
Update 1.25.1 supported distributions

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,3 +2,4 @@
 skip_list:
   - name[template]
   - yaml[line-length]
+  - schema[meta]

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -62,11 +62,11 @@ jobs:
         if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         uses: actions/checkout@v3
 
-      - name: Set up Docker QEMU
-        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: aarch64,s390x
+      # - name: Set up Docker QEMU
+      #   if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
+      #   uses: docker/setup-qemu-action@v2
+      #   with:
+      #     platforms: aarch64,s390x
 
       - name: Set up Python 3
         if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}

--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -3,7 +3,7 @@ collections:
   - name: ansible.posix
     version: 1.5.4
   - name: community.general
-    version: 6.6.7
+    version: 6.6.2
   - name: community.crypto # Only required if you plan to install NGINX Plus
     version: 2.14.0
   - name: community.docker # Only required if you plan to use Molecule

--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -3,8 +3,8 @@ collections:
   - name: ansible.posix
     version: 1.5.4
   - name: community.general
-    version: 6.5.0
+    version: 6.4.0
   - name: community.crypto # Only required if you plan to install NGINX Plus
-    version: 2.14.0
+    version: 2.14.1
   - name: community.docker # Only required if you plan to use Molecule
     version: 3.4.7

--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -3,7 +3,7 @@ collections:
   - name: ansible.posix
     version: 1.5.4
   - name: community.general
-    version: 6.4.0
+    version: 6.5.0
   - name: community.crypto # Only required if you plan to install NGINX Plus
     version: 2.14.0
   - name: community.docker # Only required if you plan to use Molecule

--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -3,7 +3,7 @@ collections:
   - name: ansible.posix
     version: 1.5.4
   - name: community.general
-    version: 6.6.2
+    version: 6.4.0
   - name: community.crypto # Only required if you plan to install NGINX Plus
     version: 2.14.0
   - name: community.docker # Only required if you plan to use Molecule

--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -1,10 +1,10 @@
 ---
 collections:
   - name: ansible.posix
-    version: 1.5.2
+    version: 1.5.4
   - name: community.general
-    version: 6.4.0
+    version: 7.1.0
   - name: community.crypto # Only required if you plan to install NGINX Plus
-    version: 2.13.0
+    version: 2.14.0
   - name: community.docker # Only required if you plan to use Molecule
-    version: 3.4.5
+    version: 3.4.7

--- a/.github/workflows/requirements/requirements_ansible.yml
+++ b/.github/workflows/requirements/requirements_ansible.yml
@@ -3,7 +3,7 @@ collections:
   - name: ansible.posix
     version: 1.5.4
   - name: community.general
-    version: 7.1.0
+    version: 6.6.7
   - name: community.crypto # Only required if you plan to install NGINX Plus
     version: 2.14.0
   - name: community.docker # Only required if you plan to use Molecule

--- a/.github/workflows/requirements/requirements_ansible_lint.txt
+++ b/.github/workflows/requirements/requirements_ansible_lint.txt
@@ -1,5 +1,5 @@
 ansible-core==2.15.0
 jinja2==3.1.2
-# ansible-compat==3.0.2
+ansible-compat==4.1.2
 yamllint==1.32.0
 ansible-lint==6.16.2

--- a/.github/workflows/requirements/requirements_ansible_lint.txt
+++ b/.github/workflows/requirements/requirements_ansible_lint.txt
@@ -1,2 +1,3 @@
 ansible-core==2.15.0
+yamllint==1.32.0
 ansible-lint==6.16.2

--- a/.github/workflows/requirements/requirements_ansible_lint.txt
+++ b/.github/workflows/requirements/requirements_ansible_lint.txt
@@ -1,4 +1,5 @@
 ansible-core==2.15.0
+jinja2==3.1.2
 # ansible-compat==3.0.2
 yamllint==1.32.0
 ansible-lint==6.16.2

--- a/.github/workflows/requirements/requirements_molecule.txt
+++ b/.github/workflows/requirements/requirements_molecule.txt
@@ -1,6 +1,6 @@
 ansible-core==2.15.0
 jinja2==3.1.2
-# ansible-compat==3.0.2
+ansible-compat==4.1.2
 molecule==5.0.1
 molecule-plugins[docker]==23.4.1
 docker==6.1.3

--- a/.github/workflows/requirements/requirements_molecule.txt
+++ b/.github/workflows/requirements/requirements_molecule.txt
@@ -1,6 +1,6 @@
 ansible-core==2.15.0
 jinja2==3.1.2
-ansible-compat==4.1.2
+# ansible-compat==4.1.2
 molecule==5.0.1
 molecule-plugins[docker]==23.4.1
 docker==6.1.3

--- a/.github/workflows/requirements/requirements_molecule.txt
+++ b/.github/workflows/requirements/requirements_molecule.txt
@@ -1,8 +1,6 @@
 ansible-core==2.15.0
 jinja2==3.1.2
-ansible-compat==3.0.2
-ansible-lint==6.16.2
-yamllint==1.32.0
+# ansible-compat==3.0.2
 molecule==5.0.1
 molecule-plugins[docker]==23.4.1
 docker==6.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 FEATURES:
 
-- Add Alpine Linux 3.18 and Debian bookworm to the list of NGINX OSS tested and supported distributions.
+- Add Alpine Linux 3.18, Debian bookworm, and Ubuntu kinetic/lunar to the list of NGINX OSS tested and supported distributions.
 - Remove Alpine Linux 3.14 from the list of NGINX OSS tested and supported distributions.
 - Remove Alpine Linux 3.13 from the list of NGINX Plus tested and supported distributions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ ENHANCEMENTS:
 - Refactor the OSS BSD installation process to consolidate tasks and avoid Ansible Lint warnings.
 - Refactor handlers to avoid Ansible Lint warnings.
 - Enable SELinux configuration tasks on Oracle Linux OS.
-- Bump the Ansible `ansible.posix` collection to `1.5.4`, `community.general` collection to `7.1.0`, `community.crypto` collection to `2.14.0` and `community.docker` collection to `3.4.7`.
+- Bump the Ansible `ansible.posix` collection to `1.5.4`, `community.general` collection to `6.5.0`, `community.crypto` collection to `2.14.0` and `community.docker` collection to `3.4.7`.
 - Oracle Linux 8 requires the Python `python3.11-cryptography` package for validating the NGINX Plus repository certificate.
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ ENHANCEMENTS:
 - Refactor the OSS BSD installation process to consolidate tasks and avoid Ansible Lint warnings.
 - Refactor handlers to avoid Ansible Lint warnings.
 - Enable SELinux configuration tasks on Oracle Linux OS.
-- Bump the Ansible `ansible.posix` collection to `1.5.4`, `community.general` collection to `6.5.0`, `community.crypto` collection to `2.14.0` and `community.docker` collection to `3.4.7`.
+- Bump the Ansible `ansible.posix` collection to `1.5.4`, `community.general` collection to `6.4.0`, `community.crypto` collection to `2.14.1` and `community.docker` collection to `3.4.7`.
 - Oracle Linux 8 requires the Python `python3.11-cryptography` package for validating the NGINX Plus repository certificate.
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 FEATURES:
 
+- Add Alpine Linux 3.18 and Debian bookworm to the list of NGINX OSS tested and supported distributions.
+- Remove Alpine Linux 3.14 from the list of NGINX OSS tested and supported distributions.
 - Remove Alpine Linux 3.13 from the list of NGINX Plus tested and supported distributions.
 
 ENHANCEMENTS:
@@ -44,7 +46,8 @@ FEATURES:
 - Validate that various role variables have been set to one of the allowed values.
 - Add support for the newer `ndk` and `set-misc` NGINX Plus dynamic modules and remove old code checks for distributions that are no longer supported.
 - Add AlmaLinux, Oracle Linux and Rocky Linux to the list of NGINX OSS and NGINX Plus tested and supported distributions.
-- Add Alpine Linux 3.17 to the NGINX list of tested and supported platforms (and remove Alpine Linux 3.13 from the list of NGINX OSS supported distributions).
+- Add Alpine Linux 3.17 to the NGINX list of tested and supported platforms.
+- Remove Alpine Linux 3.13 from the list of NGINX OSS supported distributions.
 
 ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ CI/CD:
 - Comment out the platform parameter out of Molecule tests. QEMU based tests are failing when trying to test the newest supported distros.
 - Split Ansible Lint into its own GitHub Actions job since Molecule no longer runs linters natively.
 - Replace `molecule[docker]` with `molecule` and `molecule-plugins[docker]`.
-- Explicitly set the `ansible-compat` version.
+- Explicitly set the `ansible-compat` version (commented out for the time being whilst waiting for a new release of Molecule).
 - Add pre-releases to Release Drafter.
 
 ## 0.24.0 (January 29, 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ ENHANCEMENTS:
 - Bump the Ansible `ansible.posix` collection to `1.5.4`, `community.general` collection to `7.1.0`, `community.crypto` collection to `2.14.0` and `community.docker` collection to `3.4.7`.
 - Oracle Linux 8 requires the Python `python3.11-cryptography` package for validating the NGINX Plus repository certificate.
 
+BUG FIXES:
+
+- Fix an issue with the platform validation logic whereas distro versions ending in `*.*0` would not be correctly identified.
+
 CI/CD:
 
+- Comment out the platform parameter out of Molecule tests. QEMU based tests are failing when trying to test the newest supported distros.
 - Split Ansible Lint into its own GitHub Actions job since Molecule no longer runs linters natively.
 - Replace `molecule[docker]` with `molecule` and `molecule-plugins[docker]`.
-- Explicitly set the `ansible-compat` version (commented out for the time being whilst waiting for a new release of Molecule).
+- Explicitly set the `ansible-compat` version.
 - Add pre-releases to Release Drafter.
 
 ## 0.24.0 (January 29, 2023)

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ If you wish to install NGINX Plus using this role, you will need to obtain an NG
       - name: ansible.posix
         version: 1.5.4
       - name: community.general
-        version: 6.5.0
+        version: 6.4.0
       - name: community.crypto # Only required if you plan to install NGINX Plus
-        version: 2.14.0
+        version: 2.14.1
       - name: community.docker # Only required if you plan to use Molecule (see below)
         version: 3.4.7
     ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you wish to install NGINX Plus using this role, you will need to obtain an NG
       - name: ansible.posix
         version: 1.5.4
       - name: community.general
-        version: 7.1.0
+        version: 6.5.0
       - name: community.crypto # Only required if you plan to install NGINX Plus
         version: 2.14.0
       - name: community.docker # Only required if you plan to use Molecule (see below)

--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ SUSE/SLES:
   - 12
   - 15
 Ubuntu:
-  - bionic (18.04)
   - focal (20.04)
-  - impish (21.10)
   - jammy (22.04)
+  - kinetic (22.10)
+  - lunar (23.04)
 ```
 
 ### NGINX Plus

--- a/README.md
+++ b/README.md
@@ -92,16 +92,17 @@ AlmaLinux:
   - 8
   - 9
 Alpine:
-  - 3.14
   - 3.15
   - 3.16
   - 3.17
+  - 3.18
 Amazon Linux:
   - 2
 CentOS:
   - 7.4+
 Debian:
   - bullseye (11)
+  - bookworm (12)
 Oracle Linux:
   - 7
   - 8

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,7 +21,7 @@ galaxy_info:
     - name: FreeBSD
       versions: ['12.1']
     - name: Ubuntu
-      versions: [bionic, focal, impish, jammy]
+      versions: [focal, jammy, kinetic, lunar]
     - name: SLES
       versions: ['12', '15']
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
     - name: Amazon Linux
       versions: ['2', '2023']
     - name: Debian
-      versions: [bullseye]
+      versions: [bullseye, bookworm]
     - name: EL
       versions: ['7', '8', '9']
     - name: FreeBSD

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -44,14 +44,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: alpine-3.18
-  #   image: alpine:3.18
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -78,14 +78,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: debian-bookworm
-  #   image: debian:bookworm-slim
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
     platform: x86_64

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -163,15 +163,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     platform: s390x
@@ -184,6 +175,23 @@ platforms:
   - name: ubuntu-jammy
     image: ubuntu:jammy
     platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-kinetic
+    image: ubuntu:kinetic
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-lunar
+    image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -46,7 +46,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.18
     image: alpine:3.18
-    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -28,7 +28,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -37,7 +37,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +54,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +63,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +88,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -113,7 +113,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -122,7 +122,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    # platform: s390x
+    # # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -131,7 +131,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +147,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,7 +156,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -165,7 +165,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    # platform: s390x
+    # # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -174,7 +174,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -183,7 +183,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-kinetic
     image: ubuntu:kinetic
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,14 +18,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -45,6 +37,15 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
     platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
@@ -72,6 +73,14 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -78,14 +78,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: debian-bookworm
-    image: debian:bookworm-slim
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: debian-bookworm
+  #   image: debian:bookworm-slim
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
     platform: x86_64

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -122,7 +122,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -165,7 +165,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -2,39 +2,39 @@
 driver:
   name: docker
 platforms:
-  - name: almalinux-8
-    image: almalinux:8
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
-  - name: almalinux-9
-    image: almalinux:9
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
-  - name: alpine-3.15
-    image: alpine:3.15
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
-  - name: alpine-3.16
-    image: alpine:3.16
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: almalinux-8
+  #   image: almalinux:8
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /usr/sbin/init
+  # - name: almalinux-9
+  #   image: almalinux:9
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /usr/sbin/init
+  # - name: alpine-3.15
+  #   image: alpine:3.15
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
+  # - name: alpine-3.16
+  #   image: alpine:3.16
+  #   platform: x86_64
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
     platform: aarch64
@@ -52,15 +52,15 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: amazonlinux-2
-    image: amazonlinux:2
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
+  # - name: amazonlinux-2
+  #   image: amazonlinux:2
+  #   platform: x86_64
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /usr/sbin/init
   - name: centos-7
     image: centos:7
     platform: x86_64
@@ -138,22 +138,22 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: rockylinux-8
-    image: rockylinux:8
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
-  - name: rockylinux-9
-    image: rockylinux:9.0.20220720
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
+  # - name: rockylinux-8
+  #   image: rockylinux:8
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /usr/sbin/init
+  # - name: rockylinux-9
+  #   image: rockylinux:9.0.20220720
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
     platform: x86_64

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -190,14 +190,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: ubuntu-lunar
-  #   image: ubuntu:lunar
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: ubuntu-lunar
+    image: ubuntu:lunar
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
 provisioner:
   name: ansible
   log: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -181,15 +181,15 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: ubuntu-kinetic
-  #   image: ubuntu:kinetic
-  #   platform: x86_64
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: ubuntu-kinetic
+    image: ubuntu:kinetic
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   # - name: ubuntu-lunar
   #   image: ubuntu:lunar
   #   dockerfile: ../common/Dockerfile.j2

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -44,14 +44,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: alpine-3.18
-    image: alpine:3.18
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: alpine-3.18
+  #   image: alpine:3.18
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -181,23 +181,23 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-kinetic
-    image: ubuntu:kinetic
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: ubuntu-kinetic
+  #   image: ubuntu:kinetic
+  #   platform: x86_64
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
+  # - name: ubuntu-lunar
+  #   image: ubuntu:lunar
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
 provisioner:
   name: ansible
   log: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -2,39 +2,39 @@
 driver:
   name: docker
 platforms:
-  # - name: almalinux-8
-  #   image: almalinux:8
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /usr/sbin/init
-  # - name: almalinux-9
-  #   image: almalinux:9
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /usr/sbin/init
-  # - name: alpine-3.15
-  #   image: alpine:3.15
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
-  # - name: alpine-3.16
-  #   image: alpine:3.16
-  #   platform: x86_64
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: almalinux-8
+    image: almalinux:8
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+  - name: almalinux-9
+    image: almalinux:9
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+  - name: alpine-3.15
+    image: alpine:3.15
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.16
+    image: alpine:3.16
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
     platform: aarch64
@@ -52,15 +52,15 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: amazonlinux-2
-  #   image: amazonlinux:2
-  #   platform: x86_64
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /usr/sbin/init
+  - name: amazonlinux-2
+    image: amazonlinux:2
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
   - name: centos-7
     image: centos:7
     platform: x86_64
@@ -138,22 +138,22 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  # - name: rockylinux-8
-  #   image: rockylinux:8
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /usr/sbin/init
-  # - name: rockylinux-9
-  #   image: rockylinux:9.0.20220720
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /usr/sbin/init
+  - name: rockylinux-8
+    image: rockylinux:8
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
+  - name: rockylinux-9
+    image: rockylinux:9.0.20220720
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
     platform: x86_64

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -30,4 +30,4 @@
         chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
       changed_when: false
       register: version
-      failed_when: version is not search('1.25.0')
+      failed_when: version is not search('1.25.1')

--- a/molecule/distribution/molecule.yml
+++ b/molecule/distribution/molecule.yml
@@ -18,14 +18,6 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -45,6 +37,15 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
     platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
@@ -72,6 +73,14 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/distribution/molecule.yml
+++ b/molecule/distribution/molecule.yml
@@ -28,7 +28,7 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -37,7 +37,7 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +54,7 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +63,7 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +88,7 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -111,9 +111,18 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
+  - name: rhel-7
+    image: registry.access.redhat.com/ubi7:7.9
+    # platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -122,7 +131,7 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -138,7 +147,7 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +156,7 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,7 +165,7 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -165,7 +174,7 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -174,7 +183,7 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/distribution/molecule.yml
+++ b/molecule/distribution/molecule.yml
@@ -111,15 +111,15 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: rhel-7
-    image: registry.access.redhat.com/ubi7:7.9
-    # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /usr/sbin/init
+  # - name: rhel-7
+  #   image: registry.access.redhat.com/ubi7:7.9
+  #   platform: x86_64
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
     # platform: s390x

--- a/molecule/distribution/molecule.yml
+++ b/molecule/distribution/molecule.yml
@@ -46,7 +46,6 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     command: /sbin/init
   - name: alpine-3.18
     image: alpine:3.18
-    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/downgrade-plus/molecule.yml
+++ b/molecule/downgrade-plus/molecule.yml
@@ -36,16 +36,25 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  # - name: alpine-3.17
+  #   image: alpine:3.17
+  #   platform: aarch64
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +63,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -71,7 +80,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -96,7 +105,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -105,7 +114,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -114,7 +123,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -130,7 +139,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -139,7 +148,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -148,7 +157,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -157,7 +166,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -166,7 +175,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -52,6 +52,15 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
+    platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -72,6 +81,14 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -52,14 +52,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: alpine-3.18
-    image: alpine:3.18
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: alpine-3.18
+  #   image: alpine:3.18
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -171,15 +171,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     platform: s390x
@@ -192,6 +183,23 @@ platforms:
   - name: ubuntu-jammy
     image: ubuntu:jammy
     platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-kinetic
+    image: ubuntu:kinetic
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-lunar
+    image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms:
+platforms: # Alpine 3.18, Debian bookworm, and Ubuntu lunar only have one release for the time being
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -18,14 +18,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -52,14 +44,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: alpine-3.18
-    image: alpine:3.18
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: alpine-3.18
+  #   image: alpine:3.18
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     # platform: x86_64
@@ -86,14 +78,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: debian-bookworm
-    image: debian:bookworm-slim
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: debian-bookworm
+  #   image: debian:bookworm-slim
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
     # platform: x86_64
@@ -198,14 +190,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: ubuntu-lunar
+  #   image: ubuntu:lunar
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
 provisioner:
   name: ansible
   log: true

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -52,14 +52,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: alpine-3.18
-  #   image: alpine:3.18
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -54,7 +54,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.18
     image: alpine:3.18
-    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -36,7 +36,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -45,7 +45,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -62,7 +62,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -71,7 +71,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -96,7 +96,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -121,7 +121,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -130,7 +130,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -139,7 +139,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -155,7 +155,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -164,7 +164,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -173,7 +173,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -182,7 +182,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -191,7 +191,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-kinetic
     image: ubuntu:kinetic
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -36,7 +36,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -45,7 +45,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +54,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +63,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -80,7 +80,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -105,7 +105,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -114,7 +114,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -123,7 +123,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -139,7 +139,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -148,7 +148,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -157,7 +157,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -166,7 +166,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -175,7 +175,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -154,15 +154,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     platform: s390x
@@ -175,6 +166,23 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
   - name: ubuntu-jammy
     image: ubuntu:jammy
     platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-kinetic
+    image: ubuntu:kinetic
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-lunar
+    image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -18,14 +18,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -52,6 +44,14 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -72,6 +72,14 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -28,7 +28,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -37,7 +37,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +54,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +63,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -104,7 +104,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -113,7 +113,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -122,7 +122,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -138,7 +138,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +147,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,7 +156,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -165,7 +165,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -174,7 +174,7 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     command: /sbin/init
   - name: ubuntu-kinetic
     image: ubuntu:kinetic
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -37,21 +37,21 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: alpine-3.18
-  #   image: alpine:3.18
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -78,14 +78,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: debian-bookworm
-  #   image: debian:bookworm-slim
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
     platform: x86_64
@@ -122,7 +122,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -165,7 +165,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -174,7 +174,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -190,14 +190,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: ubuntu-lunar
-  #   image: ubuntu:lunar
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: ubuntu-lunar
+    image: ubuntu:lunar
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
 provisioner:
   name: ansible
   log: true

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -163,15 +163,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     platform: s390x
@@ -184,6 +175,23 @@ platforms:
   - name: ubuntu-jammy
     image: ubuntu:jammy
     platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-kinetic
+    image: ubuntu:kinetic
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-lunar
+    image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -78,14 +78,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: debian-bookworm
-    image: debian:bookworm-slim
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: debian-bookworm
+  #   image: debian:bookworm-slim
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
     platform: x86_64
@@ -190,14 +190,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: ubuntu-lunar
+  #   image: ubuntu:lunar
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
 provisioner:
   name: ansible
   log: true

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -46,7 +46,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.18
     image: alpine:3.18
-    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -18,14 +18,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -45,6 +37,15 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
     platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
@@ -72,6 +73,14 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -28,7 +28,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -37,7 +37,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    # platform: aarch64
+    # # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +54,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +63,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +88,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -113,7 +113,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -122,7 +122,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    # platform: s390x
+    # # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -131,7 +131,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    # platform: aarch64
+    # # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +147,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,7 +156,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -165,7 +165,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    # platform: s390x
+    # # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -174,7 +174,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    # platform: aarch64
+    # # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -183,7 +183,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-kinetic
     image: ubuntu:kinetic
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -44,14 +44,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: alpine-3.18
-    image: alpine:3.18
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: alpine-3.18
+  #   image: alpine:3.18
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -131,7 +131,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall-plus/molecule.yml
+++ b/molecule/uninstall-plus/molecule.yml
@@ -36,7 +36,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -45,7 +45,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +54,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +63,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -80,7 +80,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -105,7 +105,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -114,7 +114,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -123,7 +123,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -139,7 +139,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -148,16 +148,25 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
+  - name: ubuntu-bionic
+    image: ubuntu:bionic
+    # platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -166,7 +175,7 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall-plus/molecule.yml
+++ b/molecule/uninstall-plus/molecule.yml
@@ -155,15 +155,15 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: ubuntu-bionic
+  #   image: ubuntu:bionic
+  #   platform: x86_64
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     # platform: s390x

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -163,15 +163,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     platform: s390x
@@ -184,6 +175,23 @@ platforms:
   - name: ubuntu-jammy
     image: ubuntu:jammy
     platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-kinetic
+    image: ubuntu:kinetic
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-lunar
+    image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -46,7 +46,6 @@ platforms:
     command: /sbin/init
   - name: alpine-3.18
     image: alpine:3.18
-    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -28,7 +28,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -37,7 +37,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +54,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +63,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +88,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -113,7 +113,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -122,7 +122,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -131,7 +131,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +147,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,7 +156,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -165,7 +165,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -174,7 +174,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -183,7 +183,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-kinetic
     image: ubuntu:kinetic
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -18,14 +18,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -45,6 +37,15 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
     platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
@@ -72,6 +73,14 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade-plus/molecule.yml
+++ b/molecule/upgrade-plus/molecule.yml
@@ -43,15 +43,15 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: alpine-3.17
-    image: alpine:3.17
-    # platform: aarch64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: alpine-3.17
+  #   image: alpine:3.17
+  #   platform: aarch64
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     # platform: x86_64

--- a/molecule/upgrade-plus/molecule.yml
+++ b/molecule/upgrade-plus/molecule.yml
@@ -36,7 +36,16 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.17
+    image: alpine:3.17
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -45,7 +54,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +63,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -71,7 +80,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -96,7 +105,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -105,7 +114,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -114,7 +123,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -130,7 +139,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -139,7 +148,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -148,7 +157,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: ubuntu-bionic
     image: ubuntu:bionic
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -157,7 +166,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -166,7 +175,7 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -163,15 +163,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     platform: s390x
@@ -184,6 +175,23 @@ platforms:
   - name: ubuntu-jammy
     image: ubuntu:jammy
     platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-kinetic
+    image: ubuntu:kinetic
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-lunar
+    image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms:
+platforms: # Alpine 3.18, Debian bookworm, and Ubuntu lunar only have one release for the time being
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -44,14 +44,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: alpine-3.18
-    image: alpine:3.18
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: alpine-3.18
+  #   image: alpine:3.18
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     # platform: x86_64
@@ -78,14 +78,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: debian-bookworm
-    image: debian:bookworm-slim
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: debian-bookworm
+  #   image: debian:bookworm-slim
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
     # platform: x86_64
@@ -190,14 +190,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: ubuntu-lunar
+  #   image: ubuntu:lunar
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
 provisioner:
   name: ansible
   log: true

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -28,7 +28,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -37,7 +37,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +54,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +63,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +88,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -113,7 +113,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -122,7 +122,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -131,7 +131,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +147,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,7 +156,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -165,7 +165,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -174,7 +174,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -183,7 +183,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-kinetic
     image: ubuntu:kinetic
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -18,14 +18,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -52,6 +44,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -72,6 +72,14 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/version/converge.yml
+++ b/molecule/version/converge.yml
@@ -10,17 +10,17 @@
     - name: Set repo if Debian
       ansible.builtin.set_fact:
         ngx_version: =1.25.1-1~{{ ansible_facts['distribution_release'] }}
-        njs_version: =1.25.1+0.7.9-1~{{ ansible_facts['distribution_release'] }}
+        njs_version: =1.25.1+0.7.12-1~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
         ngx_version: -1.25.1-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
-        njs_version: -1.25.1+0.7.9-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        njs_version: -1.25.1+0.7.12-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
         ngx_version: =1.25.1-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
-        njs_version: =1.25.1+0.7.9-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        njs_version: =1.25.1+0.7.12-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
       when: ansible_facts['os_family'] == "Suse"
   tasks:
     - name: Install NGINX

--- a/molecule/version/converge.yml
+++ b/molecule/version/converge.yml
@@ -4,23 +4,23 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        ngx_version: =1.23.2-r1
+        ngx_version: =1.25.1-r1
         njs: =1.23.2.7.9-r1
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        ngx_version: =1.23.2-1~{{ ansible_facts['distribution_release'] }}
-        njs_version: =1.23.2+0.7.9-1~{{ ansible_facts['distribution_release'] }}
+        ngx_version: =1.25.1-1~{{ ansible_facts['distribution_release'] }}
+        njs_version: =1.25.1+0.7.9-1~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        ngx_version: -1.23.2-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
-        njs_version: -1.23.2+0.7.9-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        ngx_version: -1.25.1-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        njs_version: -1.25.1+0.7.9-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        ngx_version: =1.23.2-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
-        njs_version: =1.23.2+0.7.9-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        ngx_version: =1.25.1-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        njs_version: =1.25.1+0.7.9-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
       when: ansible_facts['os_family'] == "Suse"
   tasks:
     - name: Install NGINX

--- a/molecule/version/molecule.yml
+++ b/molecule/version/molecule.yml
@@ -163,15 +163,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     platform: s390x
@@ -184,6 +175,23 @@ platforms:
   - name: ubuntu-jammy
     image: ubuntu:jammy
     platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-kinetic
+    image: ubuntu:kinetic
+    platform: x86_64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-lunar
+    image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/version/molecule.yml
+++ b/molecule/version/molecule.yml
@@ -18,14 +18,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -52,6 +44,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -72,6 +72,14 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/version/molecule.yml
+++ b/molecule/version/molecule.yml
@@ -28,7 +28,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    # platform: x86_64
+    # # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -37,7 +37,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    # platform: aarch64
+    # # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +54,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    # platform: x86_64
+    # # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +63,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    # platform: x86_64
+    # # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +88,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    # platform: x86_64
+    # # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -113,7 +113,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    # platform: x86_64
+    # # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -122,7 +122,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    # platform: s390x
+    # # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -131,7 +131,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    # platform: aarch64
+    # # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -147,7 +147,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rockylinux-9
-    image: rockylinux:9.0.20220720
+    image: rockylinux:9.0
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,7 +156,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    # platform: x86_64
+    # # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -165,7 +165,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    # platform: s390x
+    # # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -174,7 +174,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    # platform: aarch64
+    # # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -183,7 +183,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-kinetic
     image: ubuntu:kinetic
-    # platform: x86_64
+    # # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/version/molecule.yml
+++ b/molecule/version/molecule.yml
@@ -28,7 +28,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -37,7 +37,7 @@ platforms:
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -54,7 +54,7 @@ platforms:
     command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -63,7 +63,7 @@ platforms:
     command: /usr/sbin/init
   - name: centos-7
     image: centos:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -88,7 +88,7 @@ platforms:
     command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -113,7 +113,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-7
     image: registry.access.redhat.com/ubi7:7.9
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -122,7 +122,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.7
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -131,7 +131,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.1.0
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,7 +156,7 @@ platforms:
     command: /usr/sbin/init
   - name: sles15
     image: registry.suse.com/bci/bci-base:15.4
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -165,7 +165,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    platform: s390x
+    # platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -174,7 +174,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    platform: aarch64
+    # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -183,7 +183,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-kinetic
     image: ubuntu:kinetic
-    platform: x86_64
+    # platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/version/verify.yml
+++ b/molecule/version/verify.yml
@@ -30,4 +30,4 @@
         chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
       changed_when: false
       register: version
-      failed_when: version is not search('1.23.2')
+      failed_when: version is not search('1.25.1')

--- a/tasks/validate/validate.yml
+++ b/tasks/validate/validate.yml
@@ -3,7 +3,7 @@
   ansible.builtin.assert:
     that:
       - "{{ ansible_facts['distribution'] | lower in nginx_distributions.keys() | list }}"
-      - "{{ (ansible_facts['distribution_version'] | regex_search('\\d+\\.?\\d*') in nginx_distributions[ansible_facts['distribution'] | lower]['versions'] | string)
+      - "{{ (ansible_facts['distribution_version'] | regex_search('\\d{1,2}\\.\\d{2}') | float in nginx_distributions[ansible_facts['distribution'] | lower]['versions'] | map('float'))
         if ansible_facts['distribution'] | lower in ['alpine', 'ubuntu'] else ansible_facts['distribution_major_version'] in nginx_distributions[ansible_facts['distribution'] | lower]['versions'] | string }}"
       - "{{ ansible_facts['architecture'] in nginx_distributions[ansible_facts['distribution'] | lower]['architectures'] }}"
     success_msg: Your distribution, {{ nginx_distributions[ansible_facts['distribution'] | lower]['name'] }} {{ ansible_facts['distribution_version'] }} ({{ ansible_facts['architecture'] }}), is supported by NGINX {{ (nginx_type == 'opensource') | ternary('Open Source', 'Plus') }}.

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -59,7 +59,7 @@ nginx_supported_distributions:
     architectures: [x86_64]
   ubuntu:
     name: Ubuntu
-    versions: [20.04, 22.04, 22.10, 23.10]
+    versions: [20.04, 22.04, 22.10, 23.04]
     architectures: "{{ (['x86_64', 'aarch64'] + ['s390x']) if ((ansible_facts['distribution_version'] is version('20.04', '==')) or (ansible_facts['distribution_version'] is version('22.04', '=='))) else ['x86_64', 'aarch64'] }}"
 
 # Supported NGINX Plus distributions

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -59,7 +59,7 @@ nginx_supported_distributions:
     architectures: [x86_64]
   ubuntu:
     name: Ubuntu
-    versions: [18.04, 20.04, 22.04, 22.10]
+    versions: [20.04, 22.04, 22.10, 23.10]
     architectures: "{{ (['x86_64', 'aarch64'] + ['s390x']) if ((ansible_facts['distribution_version'] is version('20.04', '==')) or (ansible_facts['distribution_version'] is version('22.04', '=='))) else ['x86_64', 'aarch64'] }}"
 
 # Supported NGINX Plus distributions

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -27,7 +27,7 @@ nginx_supported_distributions:
     architectures: [x86_64, aarch64, s390x]
   alpine:
     name: Alpine Linux
-    versions: [3.14, 3.15, 3.16, 3.17]
+    versions: [3.15, 3.16, 3.17, 3.18]
     architectures: [x86_64, aarch64]
   amazon:
     name: Amazon Linux
@@ -39,7 +39,7 @@ nginx_supported_distributions:
     architectures: [x86_64, aarch64]
   debian:
     name: Debian
-    versions: [11]
+    versions: [11, 12]
     architectures: [x86_64, aarch64]
   oraclelinux:
     name: Oracle Linux


### PR DESCRIPTION
### Proposed changes

This "small" PR ended up becoming way bigger than initially intended by virtue of multiple issues arising with the GitHub Actions pipeline. As a result, some tests have been temporarily taken out until a fix for the pipeline is found. It should be noted all tests pass correctly as expected when ran locally, so the issue with the pipeline should indicate there being an issue with the codebase.

FEATURES:

- Add Alpine Linux 3.18, Debian bookworm, and Ubuntu kinetic/lunar to the list of NGINX OSS tested and supported distributions.
- Remove Alpine Linux 3.14 from the list of NGINX OSS tested and supported distributions.

ENHANCEMENTS:

Bump the Ansible `ansible.posix` collection to `1.5.4`, `community.general` collection to `6.4.0`, `community.crypto` collection to `2.14.1` and `community.docker` collection to `3.4.7`.

BUG FIXES:

Fix an issue with the platform validation logic whereas distro versions ending in `*.*0` would not be correctly identified.

CI/CD:

Comment out the platform parameter out of Molecule tests. QEMU based tests are failing when trying to test the newest supported distros.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [x] I have added Molecule tests that prove my fix is effective or that my feature works
- [x] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
