### PR TITLE
Support NGINX Plus R30

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -2,8 +2,8 @@
 name: Molecule CI/CD
 on:
   pull_request:
-    branches:
-      - main
+    # branches:
+    #   - main
   push:
     branches:
       - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.24.2 (Unreleased)
 
+FEATURES:
+
+- Add Alpine Linux 3.18 and Debian bookworm to the list of NGINX Plus tested and supported distributions.
+- Remove Alpine Linux 3.14 and Ubuntu bionic from the list of NGINX Plus tested and supported distributions.
+
 CI/CD:
 
 - Reimplement some platforms in the upgrade & downgrade Molecule scenarios since all platforms now have at least two releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 
 - Add Alpine Linux 3.18 and Debian bookworm to the list of NGINX Plus tested and supported distributions.
 - Remove Alpine Linux 3.14 and Ubuntu bionic from the list of NGINX Plus tested and supported distributions.
+- The `geoip2` module for NGINX Plus is no longer supported on Amazon Linux.
 
 CI/CD:
 
@@ -30,11 +31,11 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-- Fix an issue with the platform validation logic whereas distro versions ending in `*.*0` would not be correctly identified.
+- Fix an issue with the platform validation logic where distribution versions ending in `*.*0` would not be correctly identified.
 
 CI/CD:
 
-- Comment out the platform parameter out of Molecule tests. QEMU based tests are failing when trying to test the newest supported distros.
+- Comment out the platform parameter out of Molecule tests. QEMU based tests are failing when trying to test the newest supported distribution.
 - Split Ansible Lint into its own GitHub Actions job since Molecule no longer runs linters natively.
 - Replace `molecule[docker]` with `molecule` and `molecule-plugins[docker]`.
 - Explicitly set the `ansible-compat` version (commented out for the time being whilst waiting for a new release of Molecule).

--- a/README.md
+++ b/README.md
@@ -132,16 +132,17 @@ AlmaLinux:
   - 8
   - 9
 Alpine:
-  - 3.14
   - 3.15
   - 3.16
   - 3.17
+  - 3.18
 Amazon Linux:
   - 2
 CentOS:
   - 7.4+
 Debian:
   - bullseye (11)
+  - bookworm (12)
 FreeBSD:
   - 12.1+
   - 13
@@ -160,7 +161,6 @@ SUSE/SLES:
   - 12
   - 15
 Ubuntu:
-  - bionic (18.04)
   - focal (20.04)
   - jammy (22.04)
 ```

--- a/molecule/downgrade-plus/converge.yml
+++ b/molecule/downgrade-plus/converge.yml
@@ -4,19 +4,19 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =27-r1
+        version: =29-r1
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =27-1~{{ ansible_facts['distribution_release'] }}
+        version: =29-1~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -27-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -29-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =27-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =29-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
       when: ansible_facts['os_family'] == "Suse"
   tasks:
     - name: Install NGINX

--- a/molecule/downgrade-plus/molecule.yml
+++ b/molecule/downgrade-plus/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms:
+platforms: # Alpine 3.18 and Debian bookworm only have one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -44,14 +44,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: alpine-3.18
-    image: alpine:3.18
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: alpine-3.18
+  #   image: alpine:3.18
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     # platform: x86_64
@@ -78,14 +78,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: debian-bookworm
-    image: debian:bookworm-slim
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: debian-bookworm
+  #   image: debian:bookworm-slim
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
     # platform: x86_64

--- a/molecule/downgrade-plus/molecule.yml
+++ b/molecule/downgrade-plus/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
+platforms:
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -18,14 +18,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -43,15 +35,23 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: alpine-3.17
-  #   image: alpine:3.17
-  #   platform: aarch64
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: alpine-3.17
+    image: alpine:3.17
+    # platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     # platform: x86_64
@@ -72,6 +72,14 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -155,15 +163,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     # platform: s390x

--- a/molecule/downgrade-plus/verify.yml
+++ b/molecule/downgrade-plus/verify.yml
@@ -30,4 +30,4 @@
         chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
       changed_when: false
       register: version
-      failed_when: version is not search('27')
+      failed_when: version is not search('29')

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -18,14 +18,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -52,6 +44,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     # platform: x86_64
@@ -72,6 +72,14 @@ platforms:
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -155,15 +163,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     # platform: s390x

--- a/molecule/plus/verify.yml
+++ b/molecule/plus/verify.yml
@@ -23,3 +23,17 @@
       ansible.builtin.uri:
         url: http://localhost
         status_code: 200
+
+    - name: Fetch the latest version of NGINX Plus
+      ansible.builtin.uri:
+        url: https://version.nginx.com/plus
+        return_content: true
+      register: nginx_version
+
+    - name: Verify the latest version of NGINX Plus has been installed
+      ansible.builtin.command: nginx -v
+      args:
+        chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
+      changed_when: false
+      register: version
+      failed_when: version is not search(nginx_version['content'] | regex_search('[0-9]+'))

--- a/molecule/uninstall-plus/molecule.yml
+++ b/molecule/uninstall-plus/molecule.yml
@@ -18,14 +18,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -45,6 +37,15 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
+    # platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
     # platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
@@ -72,6 +73,14 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -155,15 +164,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  # - name: ubuntu-bionic
-  #   image: ubuntu:bionic
-  #   platform: x86_64
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     # platform: s390x

--- a/molecule/upgrade-plus/molecule.yml
+++ b/molecule/upgrade-plus/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms:
+platforms: # Alpine 3.18 and Debian bookworm only have one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -44,14 +44,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: alpine-3.18
-    image: alpine:3.18
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: alpine-3.18
+  #   image: alpine:3.18
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     # platform: x86_64
@@ -78,14 +78,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: debian-bookworm
-    image: debian:bookworm-slim
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: debian-bookworm
+  #   image: debian:bookworm-slim
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
     # platform: x86_64

--- a/molecule/upgrade-plus/molecule.yml
+++ b/molecule/upgrade-plus/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the moment) so it's impossible to test the upgrade scenario
+platforms:
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -18,14 +18,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.14
-    image: alpine:3.14
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.15
     image: alpine:3.15
     dockerfile: ../common/Dockerfile.j2
@@ -43,15 +35,23 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: alpine-3.17
-  #   image: alpine:3.17
-  #   platform: aarch64
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: alpine-3.17
+    image: alpine:3.17
+    # platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     # platform: x86_64
@@ -72,6 +72,14 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     command: /usr/sbin/init
   - name: debian-bullseye
     image: debian:bullseye-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -155,15 +163,6 @@ platforms: # Alpine 3.17 only has one version of NGINX Plus available (at the mo
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: ubuntu-bionic
-    image: ubuntu:bionic
-    # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
     # platform: s390x

--- a/molecule/upgrade-plus/prepare.yml
+++ b/molecule/upgrade-plus/prepare.yml
@@ -22,19 +22,19 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =27-r1
+        version: =29-r1
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =27-1~{{ ansible_facts['distribution_release'] }}
+        version: =29-1~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -27-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -29-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =27-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =29-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
       when: ansible_facts['os_family'] == "Suse"
   tasks:
     - name: Install NGINX

--- a/molecule/upgrade-plus/verify.yml
+++ b/molecule/upgrade-plus/verify.yml
@@ -28,12 +28,7 @@
       ansible.builtin.uri:
         url: https://version.nginx.com/plus
         return_content: true
-      check_mode: false
-      register: nginx_versions
-
-    - name: Set NGINX Plus version
-      ansible.builtin.set_fact:
-        nginx_version: "{{ nginx_versions.content | regex_search('[0-9]+') }}"
+      register: nginx_version
 
     - name: Verify NGINX Plus has been upgraded
       ansible.builtin.command: nginx -v
@@ -41,4 +36,4 @@
         chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
       changed_when: false
       register: version
-      failed_when: version is not search(nginx_version)
+      failed_when: version is not search(nginx_version['content'] | regex_search('[0-9]+'))

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -7,21 +7,21 @@
     - '"geoip" in nginx_modules'
     - nginx_install_epel_release | bool
 
-- name: (Amazon Linux/RHEL 7) Install GeoIP2 dependency
-  when:
-    - (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] is version('7', '=='))
-      or ansible_facts['distribution'] == "Amazon"
-    - '"geoip2" in nginx_modules'
-  block:
-    - name: (Amazon Linux/RHEL 7) Check if libmaxminddb is available
-      ansible.builtin.yum:
-        list: available
-      register: packages
+# - name: (Amazon Linux/RHEL 7) Install GeoIP2 dependency
+#   when:
+#     - (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] is version('7', '=='))
+#       or ansible_facts['distribution'] == "Amazon"
+#     - '"geoip2" in nginx_modules'
+#   block:
+#     - name: (Amazon Linux/RHEL 7) Check if libmaxminddb is available
+#       ansible.builtin.yum:
+#         list: available
+#       register: packages
 
-    - name: (Amazon Linux/RHEL 7) Install libmaxminddb
-      ansible.builtin.yum:
-        name: https://rpmfind.net/linux/centos/7.9.2009/os/x86_64/Packages/libmaxminddb-1.2.0-6.el7.x86_64.rpm
-      when: "'libmaxminddb' not in packages['results']"
+#     - name: (Amazon Linux/RHEL 7) Install libmaxminddb
+#       ansible.builtin.yum:
+#         name: https://rpmfind.net/linux/centos/7.9.2009/os/x86_64/Packages/libmaxminddb-1.2.0-6.el7.x86_64.rpm
+#       when: "'libmaxminddb' not in packages['results']"
 
 - name: (AlmaLinux/Amazon Linux/Oracle Linux/RHEL/Rocky Linux) Install GeoIP2 and/or OpenTracing EPEL dependency
   when:
@@ -62,7 +62,8 @@
       or not ((ansible_facts['os_family'] == 'FreeBSD')
       or (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution_major_version'] is version('8', '>=')))
     - not (item['name'] | default(item) == 'geoip2')
-      or not (ansible_facts['os_family'] == 'Suse')
+      or not ((ansible_facts['os_family'] == 'Suse')
+      or (ansible_facts['distribution'] == 'Amazon'))
     - not (item['name'] | default(item) == 'lua')
       or not (ansible_facts['architecture'] == 's390x')
     - not (item['name'] | default(item) == 'opentracing')

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -7,21 +7,21 @@
     - '"geoip" in nginx_modules'
     - nginx_install_epel_release | bool
 
-# - name: (Amazon Linux/RHEL 7) Install GeoIP2 dependency
-#   when:
-#     - (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] is version('7', '=='))
-#       or ansible_facts['distribution'] == "Amazon"
-#     - '"geoip2" in nginx_modules'
-#   block:
-#     - name: (Amazon Linux/RHEL 7) Check if libmaxminddb is available
-#       ansible.builtin.yum:
-#         list: available
-#       register: packages
+- name: (RHEL 7) Install GeoIP2 dependency
+  when:
+    - ansible_facts['distribution'] == "RedHat"
+    - ansible_facts['distribution_major_version'] is version('7', '==')
+    - '"geoip2" in nginx_modules'
+  block:
+    - name: (RHEL 7) Check if libmaxminddb is available
+      ansible.builtin.yum:
+        list: available
+      register: packages
 
-#     - name: (Amazon Linux/RHEL 7) Install libmaxminddb
-#       ansible.builtin.yum:
-#         name: https://rpmfind.net/linux/centos/7.9.2009/os/x86_64/Packages/libmaxminddb-1.2.0-6.el7.x86_64.rpm
-#       when: "'libmaxminddb' not in packages['results']"
+    - name: (/RHEL 7) Install libmaxminddb
+      ansible.builtin.yum:
+        name: https://rpmfind.net/linux/centos/7.9.2009/os/x86_64/Packages/libmaxminddb-1.2.0-6.el7.x86_64.rpm
+      when: "'libmaxminddb' not in packages['results']"
 
 - name: (AlmaLinux/Amazon Linux/Oracle Linux/RHEL/Rocky Linux) Install GeoIP2 and/or OpenTracing EPEL dependency
   when:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -71,7 +71,7 @@ nginx_plus_supported_distributions:
     architectures: [x86_64, aarch64]
   alpine:
     name: Alpine Linux
-    versions: [3.13, 3.14, 3.15, 3.16, 3.17]
+    versions: [3.15, 3.16, 3.17, 3.18]
     architectures: [x86_64, aarch64]
   amazon:
     name: Amazon Linux
@@ -83,7 +83,7 @@ nginx_plus_supported_distributions:
     architectures: [x86_64, aarch64]
   debian:
     name: Debian
-    versions: [11]
+    versions: [11, 12]
     architectures: [x86_64, aarch64]
   freebsd:
     name: FreeBSD
@@ -107,7 +107,7 @@ nginx_plus_supported_distributions:
     architectures: [x86_64]
   ubuntu:
     name: Ubuntu
-    versions: [18.04, 20.04, 22.04]
+    versions: [20.04, 22.04]
     architectures: "{{ (['x86_64', 'aarch64'] + ['s390x']) if (ansible_facts['distribution_version'] is version('20.04', '>=')) else ['x86_64', 'aarch64'] }}"
 
 # Default NGINX signing key


### PR DESCRIPTION
### Proposed changes

- Add Alpine Linux 3.18 and Debian bookworm to the list of NGINX Plus tested and supported distributions.
- Remove Alpine Linux 3.14 and Ubuntu bionic from the list of NGINX Plus tested and supported distributions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works
- [ ] I have checked that any relevant Molecule tests pass after adding my changes
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md))
