### PR TITLE
Remove Ubuntu kinetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 FEATURES:
 
 - Add Alpine Linux 3.18 and Debian bookworm to the list of NGINX Plus tested and supported distributions.
+- Remove Ubuntu kinetic from the list of NGINX OSS tested and supported distributions.
 - Remove Alpine Linux 3.14 and Ubuntu bionic from the list of NGINX Plus tested and supported distributions.
 - The `geoip2` module for NGINX Plus is no longer supported on Amazon Linux.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ SUSE/SLES:
 Ubuntu:
   - focal (20.04)
   - jammy (22.04)
-  - kinetic (22.10)
   - lunar (23.04)
 ```
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,7 +23,7 @@ galaxy_info:
     - name: OracleLinux
       versions: ['7', '8', '9']
     - name: Ubuntu
-      versions: [focal, jammy, kinetic, lunar]
+      versions: [focal, jammy, lunar]
     - name: SLES
       versions: ['12', '15']
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -181,15 +181,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-kinetic
-    image: ubuntu:kinetic
-    # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-lunar
     image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -181,15 +181,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-kinetic
-    image: ubuntu:kinetic
-    # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-lunar
     image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -172,15 +172,6 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-kinetic
-    image: ubuntu:kinetic
-    # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-lunar
     image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -181,15 +181,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-kinetic
-    image: ubuntu:kinetic
-    # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-lunar
     image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -181,15 +181,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-kinetic
-    image: ubuntu:kinetic
-    # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-lunar
     image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -181,15 +181,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-kinetic
-    image: ubuntu:kinetic
-    # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-lunar
     image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/version/molecule.yml
+++ b/molecule/version/molecule.yml
@@ -181,15 +181,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-kinetic
-    image: ubuntu:kinetic
-    # # platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-lunar
     image: ubuntu:lunar
     dockerfile: ../common/Dockerfile.j2


### PR DESCRIPTION
### Proposed changes

Remove Ubuntu kinetic from the list of NGINX OSS tested and supported distributions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document.
- [x] I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md)).
