### PR TITLE
Update Molecule to support NGINX Plus R31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.24.3 (Unreleased)
 
+FEATURES:
+
+- Add Alpine Linux 3.19 to the list of NGINX Plus tested and supported distributions.
+- Remove Alpine Linux 3.15 from the list of NGINX Plus tested and supported distributions.
+
 ENHANCEMENTS:
 
 - Allow strings in addition to a list when configuring `logrotate`.

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ AlmaLinux:
   - 8
   - 9
 Alpine:
-  - 3.15
   - 3.16
   - 3.17
   - 3.18
+  - 3.19
 Amazon Linux:
   - 2
 CentOS:
@@ -146,6 +146,7 @@ Debian:
 FreeBSD:
   - 12.1+
   - 13
+  - 14
 Oracle Linux:
   - 7.4+
   - 8.1+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
     - name: EL
       versions: ['7', '8', '9']
     - name: FreeBSD
-      versions: ['12.1', '12.2', '12.3', '12.4', '13.0', '13.1', '13.2']
+      versions: ['12.1', '12.2', '12.3', '12.4', '13.0', '13.1', '13.2', '14']
     - name: OracleLinux
       versions: ['7', '8', '9']
     - name: Ubuntu

--- a/molecule/downgrade-plus/converge.yml
+++ b/molecule/downgrade-plus/converge.yml
@@ -4,19 +4,19 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =29-r1
+        version: =30-r1
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =29-1~{{ ansible_facts['distribution_release'] }}
+        version: =30-1~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -29-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -30-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =29-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =30-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
       when: ansible_facts['os_family'] == "Suse"
   tasks:
     - name: Install NGINX

--- a/molecule/downgrade-plus/molecule.yml
+++ b/molecule/downgrade-plus/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms: # Alpine 3.18 and Debian bookworm only have one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
+platforms: # Alpine 3.19 only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -18,14 +18,6 @@ platforms: # Alpine 3.18 and Debian bookworm only have one version of NGINX Plus
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.15
-    image: alpine:3.15
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
     platform: x86_64
@@ -44,8 +36,16 @@ platforms: # Alpine 3.18 and Debian bookworm only have one version of NGINX Plus
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: alpine-3.18
-  #   image: alpine:3.18
+  - name: alpine-3.18
+    image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  # - name: alpine-3.19
+  #   image: alpine:3.19
   #   dockerfile: ../common/Dockerfile.j2
   #   privileged: true
   #   cgroupns_mode: host
@@ -78,14 +78,14 @@ platforms: # Alpine 3.18 and Debian bookworm only have one version of NGINX Plus
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: debian-bookworm
-  #   image: debian:bookworm-slim
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
     platform: x86_64

--- a/molecule/downgrade-plus/verify.yml
+++ b/molecule/downgrade-plus/verify.yml
@@ -30,4 +30,4 @@
         chdir: "{{ ((ansible_facts['system'] | lower is not search('bsd')) | ternary('/etc/nginx', '/usr/local/sbin')) }}"
       changed_when: false
       register: version
-      failed_when: version is not search('29')
+      failed_when: version is not search('30')

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -18,14 +18,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.15
-    image: alpine:3.15
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
     platform: x86_64
@@ -46,6 +38,14 @@ platforms:
     command: /sbin/init
   - name: alpine-3.18
     image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.19
+    image: alpine:3.19
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall-plus/molecule.yml
+++ b/molecule/uninstall-plus/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible core 2.13
+platforms:
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -18,14 +18,6 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.15
-    image: alpine:3.15
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
     platform: x86_64
@@ -46,7 +38,14 @@ platforms: # Ubuntu bionic results in a segmentation fault error as of Ansible c
     command: /sbin/init
   - name: alpine-3.18
     image: alpine:3.18
-    # platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.19
+    image: alpine:3.19
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade-plus/molecule.yml
+++ b/molecule/upgrade-plus/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms: # Alpine 3.18 and Debian bookworm only have one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
+platforms: # Alpine 3.19 only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -18,14 +18,6 @@ platforms: # Alpine 3.18 and Debian bookworm only have one version of NGINX Plus
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.15
-    image: alpine:3.15
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.16
     image: alpine:3.16
     platform: x86_64
@@ -44,14 +36,22 @@ platforms: # Alpine 3.18 and Debian bookworm only have one version of NGINX Plus
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: alpine-3.18
-  #   image: alpine:3.18
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: alpine-3.18
+    image: alpine:3.18
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.19
+    image: alpine:3.19
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -78,14 +78,14 @@ platforms: # Alpine 3.18 and Debian bookworm only have one version of NGINX Plus
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: debian-bookworm
-  #   image: debian:bookworm-slim
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: debian-bookworm
+    image: debian:bookworm-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-7
     image: oraclelinux:7
     platform: x86_64

--- a/molecule/upgrade-plus/molecule.yml
+++ b/molecule/upgrade-plus/molecule.yml
@@ -44,14 +44,14 @@ platforms: # Alpine 3.19 only has one version of NGINX Plus available (at the mo
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: alpine-3.19
-    image: alpine:3.19
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: alpine-3.19
+  #   image: alpine:3.19
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64

--- a/molecule/upgrade-plus/prepare.yml
+++ b/molecule/upgrade-plus/prepare.yml
@@ -22,19 +22,19 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =29-r1
+        version: =30-r1
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =29-1~{{ ansible_facts['distribution_release'] }}
+        version: =30-1~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -29-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -30-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary('amzn2', ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =29-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =30-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
       when: ansible_facts['os_family'] == "Suse"
   tasks:
     - name: Install NGINX

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -71,7 +71,7 @@ nginx_plus_supported_distributions:
     architectures: [x86_64, aarch64]
   alpine:
     name: Alpine Linux
-    versions: [3.15, 3.16, 3.17, 3.18]
+    versions: [3.16, 3.17, 3.18, 3.19]
     architectures: [x86_64, aarch64]
   amazon:
     name: Amazon Linux
@@ -87,7 +87,7 @@ nginx_plus_supported_distributions:
     architectures: [x86_64, aarch64]
   freebsd:
     name: FreeBSD
-    versions: [12, 13]
+    versions: [12, 13, 14]
     architectures: [x86_64]
   oraclelinux:
     name: Oracle Linux


### PR DESCRIPTION
### Proposed changes

- Add Alpine Linux 3.19 to the list of NGINX Plus tested and supported distributions.
- Remove Alpine Linux 3.15 from the list of NGINX Plus tested and supported distributions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document.
- [x] I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md)).
