### PR TITLE
Use local role name in Molecule tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ BUG FIXES:
 CI/CD:
 
 - Add Molecule tests for NGINX Amplify.
-- Use the local role name instead of fully qualified role name in Molecule to ensure tests always work as intended in environments where the role has been already installed beforehand.
+- Use the local role name (`ansible-role-nginx`) instead of the  fully qualified role name (`nginxinc.nginx`) in Molecule to ensure tests always work as intended in environments where the role has been already installed beforehand.
 
 ## 0.24.2 (October 3rd, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 CI/CD:
 
 - Add Molecule tests for NGINX Amplify.
+- Use the local role name instead of fully qualified role name in Molecule to ensure tests always work as intended in environments where the role has been already installed beforehand.
 
 ## 0.24.2 (October 3rd, 2023)
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Install NGINX
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_modules:
           - geoip

--- a/molecule/distribution/converge.yml
+++ b/molecule/distribution/converge.yml
@@ -4,6 +4,6 @@
   tasks:
     - name: Install NGINX
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_install_from: os_repository

--- a/molecule/downgrade-plus/converge.yml
+++ b/molecule/downgrade-plus/converge.yml
@@ -21,7 +21,7 @@
   tasks:
     - name: Install NGINX
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_type: plus
         nginx_license:

--- a/molecule/downgrade/converge.yml
+++ b/molecule/downgrade/converge.yml
@@ -21,6 +21,6 @@
   tasks:
     - name: Install NGINX
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_version: "{{ version }}"

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Install NGINX Plus
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_type: plus
         nginx_license:

--- a/molecule/source-version/converge.yml
+++ b/molecule/source-version/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Install NGINX from source
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_install_from: source
         nginx_branch: stable

--- a/molecule/source/converge.yml
+++ b/molecule/source/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Install NGINX from source
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_install_from: source
         nginx_branch: stable

--- a/molecule/stable/converge.yml
+++ b/molecule/stable/converge.yml
@@ -4,6 +4,6 @@
   tasks:
     - name: Install NGINX
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_branch: stable

--- a/molecule/uninstall-plus/converge.yml
+++ b/molecule/uninstall-plus/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Uninstall NGINX
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_type: plus
         nginx_setup_license: false

--- a/molecule/uninstall/converge.yml
+++ b/molecule/uninstall/converge.yml
@@ -4,6 +4,6 @@
   tasks:
     - name: Uninstall NGINX
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_setup: uninstall

--- a/molecule/upgrade-plus/converge.yml
+++ b/molecule/upgrade-plus/converge.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Install NGINX Plus
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_type: plus
         nginx_license:

--- a/molecule/upgrade/converge.yml
+++ b/molecule/upgrade/converge.yml
@@ -4,6 +4,6 @@
   tasks:
     - name: Install NGINX
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_setup: upgrade

--- a/molecule/version/converge.yml
+++ b/molecule/version/converge.yml
@@ -25,7 +25,7 @@
   tasks:
     - name: Install NGINX
       ansible.builtin.include_role:
-        name: nginxinc.nginx
+        name: ansible-role-nginx
       vars:
         nginx_version: "{{ ngx_version }}"
         nginx_modules:


### PR DESCRIPTION
### Proposed changes

Use the local role name (ansible-role-nginx) instead of the fully qualified role name (nginxinc.nginx) in Molecule to ensure tests always work as intended in environments where the role has been already installed beforehand.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document.
- [x] I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md)).
