### PR TITLE
fix: conditional statements jinja2 warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ ENHANCEMENTS:
 BUG FIXES:
 
 - Avoid re-copying the NGINX Amplify config file every time the role is run.
+- Fix conditional statements should not include jinja2 templating warning.
 
 CI/CD:
 

--- a/tasks/validate/validate.yml
+++ b/tasks/validate/validate.yml
@@ -3,8 +3,7 @@
   ansible.builtin.assert:
     that:
       - ansible_facts['distribution'] | lower in nginx_distributions.keys() | list
-      - (ansible_facts['distribution_version'] | regex_search('\\d{1,2}\\.\\d{2}') | float in nginx_distributions[ansible_facts['distribution'] | lower]['versions'] | map('float')
-        if ansible_facts['distribution'] | lower in ['alpine', 'ubuntu'] else ansible_facts['distribution_major_version'] in nginx_distributions[ansible_facts['distribution'] | lower]['versions'] | string)
+      - (ansible_facts['distribution_version'] | regex_search('\\d{1,2}\\.\\d{2}') | float in nginx_distributions[ansible_facts['distribution'] | lower]['versions'] | map('float') if ansible_facts['distribution'] | lower in ['alpine', 'ubuntu'] else ansible_facts['distribution_major_version'] in nginx_distributions[ansible_facts['distribution'] | lower]['versions'] | string)
       - ansible_facts['architecture'] in nginx_distributions[ansible_facts['distribution'] | lower]['architectures']
     success_msg: Your distribution, {{ nginx_distributions[ansible_facts['distribution'] | lower]['name'] }} {{ ansible_facts['distribution_version'] }} ({{ ansible_facts['architecture'] }}), is supported by NGINX {{ (nginx_type == 'opensource') | ternary('Open Source', 'Plus') }}.
     fail_msg: Your distribution, {{ nginx_distributions[ansible_facts['distribution'] | lower]['name'] }} {{ ansible_facts['distribution_version'] }} ({{ ansible_facts['architecture'] }}), is not supported by NGINX {{ (nginx_type == 'opensource') | ternary('Open Source', 'Plus') }}.

--- a/tasks/validate/validate.yml
+++ b/tasks/validate/validate.yml
@@ -2,10 +2,10 @@
 - name: Check whether you are using a supported NGINX distribution
   ansible.builtin.assert:
     that:
-      - "{{ ansible_facts['distribution'] | lower in nginx_distributions.keys() | list }}"
-      - "{{ (ansible_facts['distribution_version'] | regex_search('\\d{1,2}\\.\\d{2}') | float in nginx_distributions[ansible_facts['distribution'] | lower]['versions'] | map('float'))
-        if ansible_facts['distribution'] | lower in ['alpine', 'ubuntu'] else ansible_facts['distribution_major_version'] in nginx_distributions[ansible_facts['distribution'] | lower]['versions'] | string }}"
-      - "{{ ansible_facts['architecture'] in nginx_distributions[ansible_facts['distribution'] | lower]['architectures'] }}"
+      - ansible_facts['distribution'] | lower in nginx_distributions.keys() | list
+      - (ansible_facts['distribution_version'] | regex_search('\\d{1,2}\\.\\d{2}') | float in nginx_distributions[ansible_facts['distribution'] | lower]['versions'] | map('float')
+        if ansible_facts['distribution'] | lower in ['alpine', 'ubuntu'] else ansible_facts['distribution_major_version'] in nginx_distributions[ansible_facts['distribution'] | lower]['versions'] | string)
+      - ansible_facts['architecture'] in nginx_distributions[ansible_facts['distribution'] | lower]['architectures']
     success_msg: Your distribution, {{ nginx_distributions[ansible_facts['distribution'] | lower]['name'] }} {{ ansible_facts['distribution_version'] }} ({{ ansible_facts['architecture'] }}), is supported by NGINX {{ (nginx_type == 'opensource') | ternary('Open Source', 'Plus') }}.
     fail_msg: Your distribution, {{ nginx_distributions[ansible_facts['distribution'] | lower]['name'] }} {{ ansible_facts['distribution_version'] }} ({{ ansible_facts['architecture'] }}), is not supported by NGINX {{ (nginx_type == 'opensource') | ternary('Open Source', 'Plus') }}.
   when:


### PR DESCRIPTION
When ansible-core version is updated from 2.15.4 to 2.15.8 the following warning occurs:
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}

Fixed by removing the delimeters.

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document.
- [x] I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md)).
