### PR TITLE
ci: add gh action workflow for F5 CLA automation

### DIFF
--- a/.github/workflows/f5-cla.yml
+++ b/.github/workflows/f5-cla.yml
@@ -1,0 +1,35 @@
+name: "F5 CLA Workflow"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  f5-cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "F5 CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have hereby read the F5 CLA and agree to its terms') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.F5_CLA_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/beta/signatures.json'
+          path-to-document: 'https://github.com/f5/.github/blob/main/CLA/cla-markdown.md'
+          # Any pull request targeting the following branch will trigger a CLA check
+          branch: 'main'
+          custom-pr-sign-comment: 'I have hereby read the F5 CLA and agree to its terms'
+          custom-notsigned-prcomment: '🎉 Thank you for your contribution. It appears you have not yet signed the F5 Contributor License Agreement, which is required for your changes to be incorporated into an F5 project. Please kindly read the [F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md) and comment the following to agree:'
+          custom-allsigned-prcomment: 'All required contributors have signed the F5 CLA for this PR  ✅'
+          remote-organization-name: 'f5'
+          remote-repository-name: 'f5-cla-data'
+          # Comma seperated list of usernames for maintainers or any other individuals who should not be prompted for a CLA.
+          allowlist: oxpa, alessfg, bot*


### PR DESCRIPTION
### Proposed changes

Adds a GitHub actions workflow configured for F5 contributor license agreement automation and compliance. This action is configured to target a shared signature store for F5 Open Source projects. As part of the configuration, the following GitHub usernames were whitelisted as maintainers:

* `oxpa`
* `alessfg`

Any contributors not included in this whitelist will be asked to review the [F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md), upon a pull request, and post a comment agreeing to the terms before their contribution is merged.  

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document.
- [x] I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md)).
