### PR TITLE
Update list of supported NGINX versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 FEATURES:
 
 - Implement the ability to install the NGINX Agent.
-- Add Amazon Linux 2023, Alpine Linux 3.19 and Ubuntu noble(24.04) to the list of NGINX OSS and NGINX Plus tested and supported distributions.
-- Add Ubuntu matic(23.10) to the list of supported NGINX OSS distributions.
-- Remove Ubuntu lunar (23.04) from the list of supported NGINX OSS distributions.
+- Add Amazon Linux 2023, Alpine Linux 3.19 and Ubuntu noble to the list of NGINX OSS and NGINX Plus tested and supported distributions.
+- Add Ubuntu matic to the list of supported NGINX OSS distributions.
+- Remove Ubuntu lunar from the list of supported NGINX OSS distributions.
 - Remove Alpine Linux 3.15 from the list of NGINX OSS and NGINX Plus tested and supported distributions.
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ FEATURES:
 - Implement the ability to install the NGINX Agent.
 - Add Amazon Linux 2023, Alpine Linux 3.19 and Ubuntu noble(24.04) to the list of NGINX OSS and NGINX Plus tested and supported distributions.
 - Add Ubuntu matic(23.10) to the list of supported NGINX OSS distributions.
-- Remove Alpine Linux 3.15 and Ubuntu lunar (23.04) from the list of supported NGINX OSS distributions.
-- Remove  from the list of NGINX OSS and NGINX Plus tested and supported distributions.
+- Remove Ubuntu lunar (23.04) from the list of supported NGINX OSS distributions.
+- Remove Alpine Linux 3.15 from the list of NGINX OSS and NGINX Plus tested and supported distributions.
 
 ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 FEATURES:
 
 - Implement the ability to install the NGINX Agent.
-- Add Amazon Linux 2023 and Alpine Linux 3.19 to the list of NGINX Open Source and NGINX Plus tested and supported distributions.
-- Remove Alpine Linux 3.15 from the list of NGINX Open Source and NGINX Plus tested and supported distributions.
+- Add Amazon Linux 2023, Alpine Linux 3.19 and Ubuntu noble(24.04) to the list of NGINX OSS and NGINX Plus tested and supported distributions.
+- Add Ubuntu matic(23.10) to the list of supported NGINX OSS distributions.
+- Remove Alpine Linux 3.15 and Ubuntu lunar (23.04) from the list of supported NGINX OSS distributions.
+- Remove  from the list of NGINX OSS and NGINX Plus tested and supported distributions.
 
 ENHANCEMENTS:
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ SUSE/SLES:
 Ubuntu:
   - focal (20.04)
   - jammy (22.04)
-  - lunar (23.04)
+  - mantic (23.10)
+  - noble (24.04)
 ```
 
 ### NGINX Plus
@@ -184,6 +185,7 @@ SUSE/SLES:
 Ubuntu:
   - focal (20.04)
   - jammy (22.04)
+  - noble (24.04)
 ```
 
 ### NGINX Agent

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -189,8 +189,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
+  - name: ubuntu-mantic
+    image: ubuntu:mantic
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/distribution/molecule.yml
+++ b/molecule/distribution/molecule.yml
@@ -189,9 +189,16 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-jammy
-    image: ubuntu:jammy
-    # platform: aarch64
+  - name: ubuntu-mantic
+    image: ubuntu:mantic
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/distribution/molecule.yml
+++ b/molecule/distribution/molecule.yml
@@ -189,6 +189,15 @@ platforms: # The RHEL UBI 7 image fails to install some NGINX dependencies when 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: ubuntu-jammy
+    image: ubuntu:jammy
+    # platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: ubuntu-mantic
     image: ubuntu:mantic
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/downgrade-plus/converge.yml
+++ b/molecule/downgrade-plus/converge.yml
@@ -4,22 +4,22 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =30-r1
+        version: =31-r1
         cacheable: true
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =30-1~{{ ansible_facts['distribution_release'] }}
+        version: =31-1~{{ ansible_facts['distribution_release'] }}
         cacheable: true
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -30-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -31-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =30-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =31-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "Suse"
   tasks:

--- a/molecule/downgrade-plus/molecule.yml
+++ b/molecule/downgrade-plus/molecule.yml
@@ -189,14 +189,14 @@ platforms: # Ubuntu noble only has one version of NGINX Plus available (at the m
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-noble
-    image: ubuntu:noble
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
+  # - name: ubuntu-noble
+  #   image: ubuntu:noble
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/downgrade-plus/molecule.yml
+++ b/molecule/downgrade-plus/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms: # Alpine 3.19 only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
+platforms: # Ubuntu noble only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -44,14 +44,14 @@ platforms: # Alpine 3.19 only has one version of NGINX Plus available (at the mo
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: alpine-3.19
-  #   image: alpine:3.19
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: alpine-3.19
+    image: alpine:3.19
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -183,6 +183,14 @@ platforms: # Alpine 3.19 only has one version of NGINX Plus available (at the mo
   - name: ubuntu-jammy
     image: ubuntu:jammy
     # platform: aarch64
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/downgrade/converge.yml
+++ b/molecule/downgrade/converge.yml
@@ -4,22 +4,22 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =1.25.3-r1
+        version: =1.25.5-r1
         cacheable: true
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =1.25.3-1~{{ ansible_facts['distribution_release'] }}
+        version: =1.25.5-1~{{ ansible_facts['distribution_release'] }}
         cacheable: true
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -1.25.3-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -1.25.5-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =1.25.3-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =1.25.5-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "Suse"
   tasks:

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -189,8 +189,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
+  - name: ubuntu-mantic
+    image: ubuntu:mantic
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -189,6 +189,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/source-version/molecule.yml
+++ b/molecule/source-version/molecule.yml
@@ -180,8 +180,16 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
+  - name: ubuntu-mantic
+    image: ubuntu:mantic
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -180,8 +180,16 @@ platforms: # Oracle Linux 7 works in local tests but bugs out in GitHub actions 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
+  - name: ubuntu-mantic
+    image: ubuntu:mantic
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -189,8 +189,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
+  - name: ubuntu-mantic
+    image: ubuntu:mantic
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall-plus/molecule.yml
+++ b/molecule/uninstall-plus/molecule.yml
@@ -189,6 +189,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -189,8 +189,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
+  - name: ubuntu-mantic
+    image: ubuntu:mantic
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade-plus/molecule.yml
+++ b/molecule/upgrade-plus/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms: # Alpine 3.19 only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
+platforms: # Ubuntu noble only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -44,14 +44,14 @@ platforms: # Alpine 3.19 only has one version of NGINX Plus available (at the mo
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: alpine-3.19
-  #   image: alpine:3.19
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: alpine-3.19
+    image: alpine:3.19
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -189,6 +189,14 @@ platforms: # Alpine 3.19 only has one version of NGINX Plus available (at the mo
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  # - name: ubuntu-noble
+  #   image: ubuntu:noble
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/upgrade-plus/prepare.yml
+++ b/molecule/upgrade-plus/prepare.yml
@@ -22,19 +22,19 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =30-r1
+        version: =31-r1
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =30-1~{{ ansible_facts['distribution_release'] }}
+        version: =31-1~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -30-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -31-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =30-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =31-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
       when: ansible_facts['os_family'] == "Suse"
   tasks:
     - name: Install NGINX

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -189,8 +189,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
+  - name: ubuntu-mantic
+    image: ubuntu:mantic
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade/prepare.yml
+++ b/molecule/upgrade/prepare.yml
@@ -4,19 +4,19 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =1.25.3-r1
+        version: =1.25.5-r1
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =1.25.3-1~{{ ansible_facts['distribution_release'] }}
+        version: =1.25.5-1~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -1.25.3-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -1.25.5-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =1.25.3-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =1.25.5-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
       when: ansible_facts['os_family'] == "Suse"
   tasks:
     - name: Install NGINX

--- a/molecule/version/converge.yml
+++ b/molecule/version/converge.yml
@@ -4,26 +4,26 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        ngx_version: =1.25.3-r1
-        njs_version: =1.25.3.0.8.2-r1
+        ngx_version: =1.25.5-r1
+        njs_version: =1.25.5.0.8.4-r1
         cacheable: true
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        ngx_version: =1.25.3-1~{{ ansible_facts['distribution_release'] }}
-        njs_version: =1.25.3+0.8.2-1~{{ ansible_facts['distribution_release'] }}
+        ngx_version: =1.25.5-1~{{ ansible_facts['distribution_release'] }}
+        njs_version: =1.25.5+0.8.4-1~{{ ansible_facts['distribution_release'] }}
         cacheable: true
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        ngx_version: -1.25.3-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
-        njs_version: -1.25.3+0.8.2-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        ngx_version: -1.25.5-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        njs_version: -1.25.5+0.8.4-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        ngx_version: =1.25.3-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
-        njs_version: =1.25.3+0.8.2-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        ngx_version: =1.25.5-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        njs_version: =1.25.5+0.8.4-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "Suse"
   tasks:

--- a/molecule/version/converge.yml
+++ b/molecule/version/converge.yml
@@ -5,25 +5,25 @@
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
         ngx_version: =1.25.5-r1
-        njs_version: =1.25.5.0.8.4-r1
+        njs_version: =1.25.5.0.8.4-r3
         cacheable: true
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
         ngx_version: =1.25.5-1~{{ ansible_facts['distribution_release'] }}
-        njs_version: =1.25.5+0.8.4-1~{{ ansible_facts['distribution_release'] }}
+        njs_version: =1.25.5+0.8.4-3~{{ ansible_facts['distribution_release'] }}
         cacheable: true
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
         ngx_version: -1.25.5-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
-        njs_version: -1.25.5+0.8.4-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        njs_version: -1.25.5+0.8.4-3.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
         ngx_version: =1.25.5-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
-        njs_version: =1.25.5+0.8.4-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        njs_version: =1.25.5+0.8.4-3.sles{{ ansible_facts['distribution_major_version'] }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "Suse"
   tasks:

--- a/molecule/version/molecule.yml
+++ b/molecule/version/molecule.yml
@@ -189,8 +189,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-lunar
-    image: ubuntu:lunar
+  - name: ubuntu-mantic
+    image: ubuntu:mantic
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/tasks/keys/setup-keys.yml
+++ b/tasks/keys/setup-keys.yml
@@ -19,13 +19,13 @@
 
 - name: (Debian/Ubuntu) Add NGINX signing key
   ansible.builtin.apt_key:
-    id: 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+    id: 8540A6F18833A80E9C1653A42FD21310B49F6B46
     keyring: /usr/share/keyrings/nginx-archive-keyring.gpg
     url: "{{ keysite }}"
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: (Red Hat/SLES OSs) Add NGINX signing key
   ansible.builtin.rpm_key:
-    fingerprint: 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+    fingerprint: 8540A6F18833A80E9C1653A42FD21310B49F6B46
     key: "{{ keysite }}"
   when: ansible_facts['os_family'] in ['RedHat', 'Suse']

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -92,11 +92,11 @@ nginx_plus_supported_distributions:
   oraclelinux:
     name: Oracle Linux
     versions: [7, 8, 9]
-    architectures: "{{ (['x86_64'] + ['aarch64']) if (ansible_facts['distribution_major_version'] is version('8', '==')) else ['x86_64'] }}"
+    architectures: "{{ ['x86_64', 'aarch64'] if (ansible_facts['distribution_major_version'] is version('8', '==')) else ['x86_64'] }}"
   redhat:
     name: Red Hat Enterprise Linux
     versions: [7, 8, 9]
-    architectures: "{{ (['x86_64', 'aarch64'] + ['s390x']) if (ansible_facts['distribution_major_version'] is version('8', '>=')) else ['x86_64', 'aarch64'] }}"
+    architectures: "{{ ['x86_64', 'aarch64', 's390x'] if (ansible_facts['distribution_major_version'] is version('8', '>=')) else ['x86_64', 'aarch64'] }}"
   rocky:
     name: Rocky Linux
     versions: [8, 9]
@@ -108,7 +108,7 @@ nginx_plus_supported_distributions:
   ubuntu:
     name: Ubuntu
     versions: [20.04, 22.04, 24.04]
-    architectures: "{{ (['x86_64', 'aarch64'] + ['s390x']) if (ansible_facts['distribution_version'] is version('20.04', '>=')) else ['x86_64', 'aarch64'] }}"
+    architectures: "{{ ['x86_64', 'aarch64', 's390x'] if ((ansible_facts['distribution_version'] is version('20.04', '==')) or (ansible_facts['distribution_version'] is version('22.04', '=='))) else ['x86_64', 'aarch64'] }}"
 
 # Default NGINX signing key
 nginx_default_signing_key_pgp: https://nginx.org/keys/nginx_signing.key

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -135,7 +135,7 @@ nginx_plus_default_repository_suse: https://pkgs.nginx.com/plus/sles/{{ ansible_
 nginx_alpine_dependencies: [ca-certificates, coreutils, openssl, pcre2]
 
 # Debian dependencies
-nginx_debian_dependencies: [apt-transport-https, ca-certificates, gpg-agent]
+nginx_debian_dependencies: [apt-transport-https, ca-certificates, gnupg, gpg-agent]
 
 # FreeBSD dependencies
 nginx_freebsd_dependencies: [security/ca_root_nss]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -44,11 +44,11 @@ nginx_supported_distributions:
   oraclelinux:
     name: Oracle Linux
     versions: [7, 8, 9]
-    architectures: "{{ (['x86_64', 'aarch64'] + ['s390x']) if (ansible_facts['distribution_major_version'] is version('8', '>=')) else ['x86_64', 'aarch64'] }}"
+    architectures: "{{ ['x86_64', 'aarch64', 's390x'] if (ansible_facts['distribution_major_version'] is version('8', '>=')) else ['x86_64', 'aarch64'] }}"
   redhat:
     name: Red Hat Enterprise Linux
     versions: [7, 8, 9]
-    architectures: "{{ (['x86_64', 'aarch64'] + ['s390x']) if (ansible_facts['distribution_major_version'] is version('8', '>=')) else ['x86_64', 'aarch64'] }}"
+    architectures: "{{ ['x86_64', 'aarch64', 's390x'] if (ansible_facts['distribution_major_version'] is version('8', '>=')) else ['x86_64', 'aarch64'] }}"
   rocky:
     name: Rocky Linux
     versions: [8, 9]
@@ -59,8 +59,8 @@ nginx_supported_distributions:
     architectures: [x86_64]
   ubuntu:
     name: Ubuntu
-    versions: [20.04, 22.04, 23.04]
-    architectures: "{{ (['x86_64', 'aarch64'] + ['s390x']) if ((ansible_facts['distribution_version'] is version('20.04', '==')) or (ansible_facts['distribution_version'] is version('22.04', '=='))) else ['x86_64', 'aarch64'] }}"
+    versions: [20.04, 22.04, 23.10, 24.04]
+    architectures: "{{ ['x86_64', 'aarch64', 's390x'] if ((ansible_facts['distribution_version'] is version('20.04', '==')) or (ansible_facts['distribution_version'] is version('22.04', '=='))) else ['x86_64', 'aarch64'] }}"
 
 # Supported NGINX Plus distributions
 # https://docs.nginx.com/nginx/technical-specs/
@@ -107,7 +107,7 @@ nginx_plus_supported_distributions:
     architectures: [x86_64]
   ubuntu:
     name: Ubuntu
-    versions: [20.04, 22.04]
+    versions: [20.04, 22.04, 24.04]
     architectures: "{{ (['x86_64', 'aarch64'] + ['s390x']) if (ansible_facts['distribution_version'] is version('20.04', '>=')) else ['x86_64', 'aarch64'] }}"
 
 # Default NGINX signing key


### PR DESCRIPTION
### Proposed changes

- Add Ubuntu noble (24.04) to the list of NGINX OSS and NGINX Plus tested and supported distributions.
- Add Ubuntu matic (23.10) to the list of supported NGINX OSS distributions.
- Remove Ubuntu lunar (23.04) from the list of supported NGINX OSS distributions.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document.
- [x] I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md)).
