### PR TITLE
Add newly released rpm signing keys

### DIFF
--- a/tasks/keys/setup-keys.yml
+++ b/tasks/keys/setup-keys.yml
@@ -17,15 +17,28 @@
     keysite: "{{ nginx_signing_key | default(nginx_default_signing_key_pgp) }}"
   when: ansible_facts['os_family'] != 'Alpine'
 
-- name: (Debian/Ubuntu) Add NGINX signing key
+- name: (Debian/Ubuntu) Add old NGINX signing key
   ansible.builtin.apt_key:
     id: 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
     keyring: /usr/share/keyrings/nginx-archive-keyring.gpg
     url: "{{ keysite }}"
   when: ansible_facts['os_family'] == 'Debian'
 
-- name: (Red Hat/SLES OSs) Add NGINX signing key
+- name: (Debian/Ubuntu) Add new NGINX signing key
+  ansible.builtin.apt_key:
+    id: 8540A6F18833A80E9C1653A42FD21310B49F6B46
+    keyring: /usr/share/keyrings/nginx-archive-keyring.gpg
+    url: "{{ keysite }}"
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: (Red Hat/SLES OSs) Add old NGINX signing key
   ansible.builtin.rpm_key:
     fingerprint: 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
+    key: "{{ keysite }}"
+  when: ansible_facts['os_family'] in ['RedHat', 'Suse']
+
+- name: (Red Hat/SLES OSs) Add new NGINX signing key
+  ansible.builtin.rpm_key:
+    fingerprint: 8540A6F18833A80E9C1653A42FD21310B49F6B46
     key: "{{ keysite }}"
   when: ansible_facts['os_family'] in ['RedHat', 'Suse']


### PR DESCRIPTION
[ENG-31696](https://logrhythm.atlassian.net/browse/ENG-31696)

# What does this change do?
Adds the new signing keys for nginx, that nginx added 2024-05-29.

# How was this change implemented?
Followed the Ubuntu steps here:
https://docs.nginx.com/nginx-agent/installation-upgrade/installation-oss/
To get the signing fingerprints (seeing both old and new keys provided), then added the new ones alongside the old ones.

# How is this change tested?
Reference the tag/release for this change in autobot-rock's requirements.yml, and see if nginx steps still fail on a key mismatch.

# Here's an awesome image for your troubles
![image](https://media.giphy.com/media/l2JdXL7JZAhJ9z4fS/giphy.gif?cid=790b7611jnp9i26o7aycqdmyoiu965r0eyruyve78faxt6o8&ep=v1_gifs_search&rid=giphy.gif&ct=g)
