### PR TITLE
ci: Reimplement testing different architectures

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -69,6 +69,14 @@ jobs:
         if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Set up QEMU
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
+        uses: docker/setup-qemu-action@5927c834f5b4fdf503fca6f4c7eccda82949e1ee # v3.1.0
+
+      - name: Set up Docker Buildx
+        if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
+        uses: docker/setup-buildx-action@4fd812986e6c8c2a69e18311145f9371337f27d4 # v3.4.0
+
       # - name: Set up Docker QEMU
       #   if: ${{ !(contains(matrix.scenario, 'plus')) || (env.NGINX_CRT != 0 && env.NGINX_KEY != 0) }}
       #   uses: docker/setup-qemu-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CI/CD:
 
 - Update GitHub Actions to Ubuntu 24.04.
 - Switch GitHub Actions from using tags to release hashes.
+- Test `aarch64` and `s390x` architectures in addition to `x86_64`.
 
 ## 0.24.3 (July 11, 2024)
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,7 +20,7 @@ platforms:
     command: /usr/sbin/init
   - name: alpine-3.17
     image: alpine:3.17
-    # platform: aarch64
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -102,7 +102,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-8
     image: redhat/ubi8:8.9
-    # platform: s390x
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -111,7 +111,7 @@ platforms:
     command: /usr/sbin/init
   - name: rhel-9
     image: redhat/ubi9:9.3
-    # platform: aarch64
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -145,7 +145,7 @@ platforms:
     command: /usr/sbin/init
   - name: ubuntu-focal
     image: ubuntu:focal
-    # platform: s390x
+    platform: s390x
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -154,7 +154,7 @@ platforms:
     command: /sbin/init
   - name: ubuntu-jammy
     image: ubuntu:jammy
-    # platform: aarch64
+    platform: aarch64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host


### PR DESCRIPTION
### Proposed changes

This PR supersedes #653. It aims to reimplement the functional tests of both `aarch64` and `s390x` architectures in addition to `x86_64`. The previous PR is very outdated a this stage so recreating it is faster than rebasing.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document.
- [ ] I have added Molecule tests that prove my fix is effective or that my feature works.
- [ ] I have checked that any relevant Molecule tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md)).
