### PR TITLE
chore: Remove platform metadata from the Ansible Galaxy role metadata

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,5 +3,4 @@ exclude_paths:
   - .github/
 skip_list:
   - name[template]
-  - schema[meta]
   - yaml[line-length]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CI/CD:
 - Update GitHub Actions to Ubuntu 24.04.
 - Switch GitHub Actions from using tags to release hashes.
 - Remove commented out Molecule platforms and GitHub Actions QEMU step for the time being. These changes will be reverted if multi-arch testing can be reinstated in GitHub Actions.
+- Remove platform metadata from the Ansible Galaxy role metadata since platforms are no longer supported in Ansible Galaxy NG.
 
 ## 0.24.3 (July 11, 2024)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,25 +7,7 @@ galaxy_info:
 
   license: Apache License, Version 2.0
 
-  min_ansible_version: '2.12'
-
-  platforms:
-    - name: Alpine
-      versions: [all]
-    - name: Amazon Linux
-      versions: ['2']
-    - name: Debian
-      versions: [bullseye, bookworm]
-    - name: EL
-      versions: ['8', '9']
-    - name: FreeBSD
-      versions: ['12.1', '12.2', '12.3', '12.4', '13.0', '13.1', '13.2', '14']
-    - name: OracleLinux
-      versions: ['8', '9']
-    - name: Ubuntu
-      versions: [focal, jammy, lunar]
-    - name: SLES
-      versions: ['12', '15']
+  min_ansible_version: '2.16'
 
   galaxy_tags:
     - nginx


### PR DESCRIPTION
### Proposed changes

Remove platform metadata from the Ansible Galaxy role metadata since platforms are no longer supported in Ansible Galaxy NG.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CONTRIBUTING.md) document.
- [x] I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](https://github.com/nginxinc/ansible-role-nginx/blob/main/defaults/main/), [`README.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/ansible-role-nginx/blob/main/CHANGELOG.md)).
