### PR TITLE
chore!: Do not omit `allow_downgrade` module parameter on Ansible <2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ BREAKING CHANGES:
 
 - Remove support for RHEL 7 based distributions (RHEL/CentOS/Oracle Linux 7). CentOS 7 has reached EoL, RHEL 7 has reached EoM, and Oracle Linux 7 will reach EoL shortly. These distributions will not be supported by new NGINX releases moving forward. If you are still using one of these distributions, please consider upgrading. If you still want to use this role for the time being, please use the previous release (0.24.3). Do note that you will only be able to use NGINX versions released as of the date of the aforementioned release (July 11, 2024).
 - Remove support for installing NGINX Open Source on Alpine Linux 3.16.
+- No longer omit `allow_downgrade` module parameter when running Ansible versions lower than `2.12`.
 
 FEATURES:
 

--- a/tasks/opensource/install-debian.yml
+++ b/tasks/opensource/install-debian.yml
@@ -27,6 +27,6 @@
     name: nginx{{ nginx_version | default('') }}
     state: "{{ nginx_state }}"
     update_cache: true
-    allow_downgrade: "{{ omit if ansible_version['full'] is version('2.12', '<') else true }}"
+    allow_downgrade: true
   ignore_errors: "{{ ansible_check_mode }}"
   notify: (Handler) Run NGINX

--- a/tasks/opensource/install-redhat.yml
+++ b/tasks/opensource/install-redhat.yml
@@ -22,6 +22,6 @@
     name: nginx{{ nginx_version | default('') }}
     state: "{{ nginx_state }}"
     update_cache: true
-    allow_downgrade: "{{ omit if ansible_version['full'] is version('2.12', '<') else true }}"
+    allow_downgrade: true
   ignore_errors: "{{ ansible_check_mode }}"
   notify: (Handler) Run NGINX

--- a/tasks/plus/install-debian.yml
+++ b/tasks/plus/install-debian.yml
@@ -25,7 +25,7 @@
     name: nginx-plus{{ nginx_version | default('') }}
     state: "{{ nginx_state }}"
     update_cache: true
-    allow_downgrade: "{{ omit if ansible_version['full'] is version('2.12', '<') else true }}"
+    allow_downgrade: true
   ignore_errors: "{{ ansible_check_mode }}"
   when: nginx_license_status is not defined
   notify: (Handler) Run NGINX

--- a/tasks/plus/install-redhat.yml
+++ b/tasks/plus/install-redhat.yml
@@ -22,7 +22,7 @@
     name: nginx-plus{{ nginx_version | default('') }}
     state: "{{ nginx_state }}"
     update_cache: true
-    allow_downgrade: "{{ omit if ansible_version['full'] is version('2.12', '<') else true }}"
+    allow_downgrade: true
   ignore_errors: "{{ ansible_check_mode }}"
   when: nginx_license_status is not defined
   notify: (Handler) Run NGINX


### PR DESCRIPTION
### Proposed changes

No longer omit `allow_downgrade` module parameter when running Ansible versions lower than `2.12`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
