### PR TITLE
chore: Remove unnecessary task when installing modules on Alpine Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ TESTS:
 
 - Update RHEL UBI images to UBI 8.10 and UBI 9.4.
 
+MAINTENANCE:
+
+- Installing certain NGINX modules on Alpine Linux 3.17 no longer requires installing `nginx-plus-module-ndk` as a separate step.
+
 CI/CD:
 
 - Update GitHub Actions to Ubuntu 24.04.

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -1,28 +1,29 @@
 ---
-- name: (AlmaLinux/Amazon Linux/Oracle Linux/RHEL/Rocky Linux) Install GeoIP2 and/or OpenTracing EPEL dependency
+- name: (AlmaLinux/Amazon Linux/Oracle Linux/RHEL/Rocky Linux) Install OpenTracing EPEL dependency
   when:
     - ansible_facts['os_family'] == "RedHat"
-    - not (ansible_facts['distribution'] == "Amazon" and ansible_facts['distribution_major_version'] is version('2023', '=='))
     - ('opentracing' in nginx_modules)
     - nginx_install_epel_release | bool
   block:
-    - name: (AlmaLinux/Amazon Linux/Oracle Linux/RHEL/Rocky Linux) Import EPEL GPG key
-      ansible.builtin.rpm_key:
-        state: present
-        key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ((ansible_facts['distribution'] == 'Amazon') | ternary('7', ansible_facts['distribution_major_version'])) }}
+    - name: (AlmaLinux/Amazon Linux/Oracle Linux/RHEL/Rocky Linux) Install EPEL dependency
+      when: ansible_facts['distribution'] != "Amazon"
+      block:
+        - name: (AlmaLinux/Oracle Linux/RHEL/Rocky Linux) Import EPEL GPG key
+          ansible.builtin.rpm_key:
+            state: present
+            key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts['distribution_major_version'] }}
 
-    - name: (AlmaLinux/Amazon Linux/Oracle Linux/RHEL/Rocky Linux) Install EPEL
-      ansible.builtin.yum:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ((ansible_facts['distribution'] == 'Amazon') | ternary('7', ansible_facts['distribution_major_version'])) }}.noarch.rpm
+        - name: (AlmaLinux/Oracle Linux/RHEL/Rocky Linux) Install EPEL
+          ansible.builtin.yum:
+            name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm
 
-- name: (Alpine Linux) Install Lua and Encrypted Sessions Alpine Linux 3.17 dependency
-  community.general.apk:
-    name: nginx-plus-module-ndk
-  when:
-    - nginx_type == 'plus'
-    - ansible_facts['os_family'] == 'Alpine'
-    - ansible_facts['distribution_version'] | regex_search('^[0-9]+\\.[0-9]+') is version('3.17', '==')
-    - ('encrypted-sessions' in nginx_modules) or ('lua' in nginx_modules) or ('set-misc' in nginx_modules)
+    - name: (Amazon Linux) Install EPEL
+      ansible.builtin.command:
+        cmd: amazon-linux-extras install -y epel
+        creates: /etc/yum.repos.d/epel.repo
+      when:
+        - ansible_facts['distribution'] == "Amazon"
+        - ansible_facts['distribution_major_version'] is version('2', '==')
 
 - name: Install NGINX modules
   ansible.builtin.package:


### PR DESCRIPTION
### Proposed changes

Installing certain NGINX modules on Alpine Linux 3.17 no longer requires installing `nginx-plus-module-ndk` as a separate step. This PR also includes a minor bug fix hat should have been part of the original PR removing support for RHEL 7 based distributions involving EPEL 7 repos being no longer available.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
