### PR TITLE
feat!: Add support for NGINX Plus R33 and the new JWT license

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -44,6 +44,7 @@ jobs:
       AMPLIFY_PASSWORD: ${{ secrets.AMPLIFY_PASSWORD }}
       NGINX_CRT: ${{ secrets.NGINX_CRT }}
       NGINX_KEY: ${{ secrets.NGINX_KEY }}
+      NGINX_JWT: ${{ secrets.NGINX_JWT }}
       ONE_API_TOKEN: ${{ secrets.ONE_API_TOKEN }}
       ONE_TENANT: ${{ secrets.ONE_TENANT }}
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,41 @@
-# Any private crt and keys #
-############################
+########################
+# Any crt/keys/license #
+########################
 *.crt
 *.key
+*.jwt
+
+##########################
+# Backup/temporary files #
+##########################
 *~
 \#*
 
-# OS Specific #
-###############
+##################
+# MacOS specific #
+##################
 Thumbs.db
 .DS_Store
 .vscode
 
+########################
+# Code editor specific #
+########################
+.idea
+.vscode
+
+####################
 # Ansible specific #
 ####################
 .cache
 *.retry
 
+###################
 # Python specific #
 ###################
 __pycache__
 
+########
 # Logs #
 ########
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 BREAKING CHANGES:
 
+- NGINX Plus requires a JWT license starting with R33. Make sure you include the path to the base64 encoded JWT license using the new `nginx_license['jwt']` parameter.
 - Remove support for RHEL 7 based distributions (RHEL/CentOS/Oracle Linux 7). CentOS 7 has reached EoL, RHEL 7 has reached EoM, and Oracle Linux 7 will reach EoL shortly. These distributions will not be supported by new NGINX releases moving forward. If you are still using one of these distributions, please consider upgrading. If you still want to use this role for the time being, please use the previous release (0.24.3). Do note that you will only be able to use NGINX versions released as of the date of the aforementioned release (July 11, 2024).
-- Remove support for installing NGINX Open Source on Alpine Linux 3.16.
+- Remove support for installing NGINX Open Source and NGINX Plus on Alpine Linux 3.16.
+- Remove support for installing NGINX Open Source on Ubuntu mantic.
 - No longer omit `allow_downgrade` module parameter when running Ansible versions lower than `2.12`.
 
 FEATURES:
@@ -13,10 +15,10 @@ FEATURES:
 - Add support for templating the entire NGINX Agent configuration file.
 - Add support for installing and configuring the NGINX Plus HA keepalived package.
 - Add validation tasks to check the Ansible version, the Jinja2 version, whether the required Ansible collections for this role are installed, and whether you are trying to install a valid NGINX module.
-- Add support for installing NGINX Open Source on Alpine Linux 3.20.
+- Add support for installing NGINX Open Source and NGINX Plus on Alpine Linux 3.20.
+- Add support for installing NGINX Open Source on Ubuntu oracular.
 - Add support for installing NGINX Agent on Ubuntu noble.
 - Bump the minimum version of Ansible supported to `2.16`, whilst clarifying that Ansible `2.18` is not supported at this stage.
-- Bump the Ansible `community.general` collection to `9.2.0`, `community.crypto` collection to `2.21.1` and `community.docker` collection to `3.11.0`.
 
 DOCUMENTATION:
 
@@ -34,7 +36,7 @@ MAINTENANCE:
 
 CI/CD:
 
-- Update GitHub Actions to Ubuntu 24.04.
+- Update GitHub Actions to Ubuntu 24.04 (noble).
 - Switch GitHub Actions from using tags to release hashes.
 - Remove commented out Molecule platforms and GitHub Actions QEMU step for the time being. These changes will be reverted if multi-arch testing can be reinstated in GitHub Actions.
 - Bump the minimum version of Ansible supported on Ansible Galaxy to `2.16`.

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -79,12 +79,16 @@ nginx_static_modules: [http_ssl_module]
 # Default is mainline.
 nginx_branch: mainline
 
-# Location of your NGINX Plus license (certificate, key, and JWT) in your local machine. The license JWT is only required with NGINX Plus R33 and later.
+# Location of your NGINX Plus license (certificate, key, and JWT) in your local machine. The license JWT is only required starting with NGINX Plus R33 and later.
+# For the license JWT, you can optionally specify a custom destination path for the JWT by using the 'src' and 'dest' parameters.
 # Default is the files folder within the NGINX Ansible role.
 nginx_license:
   certificate: license/nginx-repo.crt
   key: license/nginx-repo.key
   jwt: license/license.jwt
+  # jwt:
+  #   src: license/license.jwt
+  #   dest: /etc/nginx/license.jwt
 
 # Set up NGINX Plus license before installation.
 # Default is true.

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -79,11 +79,12 @@ nginx_static_modules: [http_ssl_module]
 # Default is mainline.
 nginx_branch: mainline
 
-# Location of your NGINX Plus license in your local machine.
+# Location of your NGINX Plus license (certificate, key, and JWT) in your local machine. The license JWT is only required with NGINX Plus R33 and later.
 # Default is the files folder within the NGINX Ansible role.
 nginx_license:
   certificate: license/nginx-repo.crt
   key: license/nginx-repo.key
+  jwt: license/license.jwt
 
 # Set up NGINX Plus license before installation.
 # Default is true.

--- a/molecule/agent/molecule.yml
+++ b/molecule/agent/molecule.yml
@@ -93,6 +93,7 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -108,7 +109,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/amplify/molecule.yml
+++ b/molecule/amplify/molecule.yml
@@ -28,7 +28,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -93,6 +93,7 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -108,7 +109,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,16 +157,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-mantic
-    image: ubuntu:mantic
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-noble
-    image: ubuntu:noble
+  - name: ubuntu-oracular
+    image: ubuntu:oracular
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/distribution/molecule.yml
+++ b/molecule/distribution/molecule.yml
@@ -93,6 +93,7 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -108,7 +109,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,16 +157,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-mantic
-    image: ubuntu:mantic
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-noble
-    image: ubuntu:noble
+  - name: ubuntu-oracular
+    image: ubuntu:oracular
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/downgrade-plus/converge.yml
+++ b/molecule/downgrade-plus/converge.yml
@@ -4,22 +4,22 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =31-r1
+        version: =32-r1
         cacheable: true
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =31-1~{{ ansible_facts['distribution_release'] }}
+        version: =32-1~{{ ansible_facts['distribution_release'] }}
         cacheable: true
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -31-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -32-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =31-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =32-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "Suse"
   tasks:

--- a/molecule/downgrade-plus/molecule.yml
+++ b/molecule/downgrade-plus/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms: # Ubuntu noble only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
+platforms: # Alpine Linux 3.20 only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -18,15 +18,6 @@ platforms: # Ubuntu noble only has one version of NGINX Plus available (at the m
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.16
-    image: alpine:3.16
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
@@ -51,6 +42,15 @@ platforms: # Ubuntu noble only has one version of NGINX Plus available (at the m
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  # - name: alpine-3.20
+  #   image: alpine:3.20
+  #   platform: x86_64
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -94,6 +94,7 @@ platforms: # Ubuntu noble only has one version of NGINX Plus available (at the m
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -109,7 +110,7 @@ platforms: # Ubuntu noble only has one version of NGINX Plus available (at the m
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -157,14 +158,14 @@ platforms: # Ubuntu noble only has one version of NGINX Plus available (at the m
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: ubuntu-noble
-  #   image: ubuntu:noble
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/downgrade-plus/prepare.yml
+++ b/molecule/downgrade-plus/prepare.yml
@@ -17,6 +17,13 @@
         force: false
         mode: "0444"
 
+    - name: Create ephemeral license JWT file from b64 encoded env var
+      ansible.builtin.copy:
+        content: "{{ lookup('env', 'NGINX_JWT') }}"
+        dest: ../../files/license/license.jwt
+        force: false
+        mode: "0444"
+
 - name: Prepare NGINX Plus
   hosts: all
   tasks:
@@ -28,3 +35,4 @@
         nginx_license:
           certificate: license/nginx-repo.crt
           key: license/nginx-repo.key
+          jwt: license/license.jwt

--- a/molecule/downgrade/converge.yml
+++ b/molecule/downgrade/converge.yml
@@ -4,22 +4,22 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =1.25.5-r1
+        version: =1.27.1-r1
         cacheable: true
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =1.25.5-1~{{ ansible_facts['distribution_release'] }}
+        version: =1.27.1-1~{{ ansible_facts['distribution_release'] }}
         cacheable: true
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -1.25.5-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -1.27.1-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =1.25.5-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =1.27.1-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "Suse"
   tasks:

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the moment) so it's impossible to test the downgrade scenario
+platforms: # Ubuntu oracular only has one version of NGINX OSS available (at the moment) so it's impossible to test the downgrade scenario
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -42,14 +42,14 @@ platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the mom
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: alpine-3.20
-  #   image: alpine:3.20
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: alpine-3.20
+    image: alpine:3.20
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -93,6 +93,7 @@ platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the mom
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -108,7 +109,7 @@ platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the mom
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,14 +157,6 @@ platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the mom
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-mantic
-    image: ubuntu:mantic
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-noble
     image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
@@ -172,6 +165,14 @@ platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the mom
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  # - name: ubuntu-oracular
+  #   image: ubuntu:oracular
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
 provisioner:
   name: ansible
   log: true

--- a/molecule/plus/converge.yml
+++ b/molecule/plus/converge.yml
@@ -10,6 +10,7 @@
         nginx_license:
           certificate: license/nginx-repo.crt
           key: license/nginx-repo.key
+          jwt: license/license.jwt
         nginx_remove_license: false
         nginx_modules:
           - auth-spnego

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -18,15 +18,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.16
-    image: alpine:3.16
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
@@ -45,6 +36,14 @@ platforms:
     command: /sbin/init
   - name: alpine-3.19
     image: alpine:3.19
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.20
+    image: alpine:3.20
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -94,6 +93,7 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -109,7 +109,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/plus/prepare.yml
+++ b/molecule/plus/prepare.yml
@@ -16,3 +16,10 @@
         dest: ../../files/license/nginx-repo.key
         force: false
         mode: "0444"
+
+    - name: Create ephemeral license JWT file from b64 encoded env var
+      ansible.builtin.copy:
+        content: "{{ lookup('env', 'NGINX_JWT') }}"
+        dest: ../../files/license/license.jwt
+        force: false
+        mode: "0444"

--- a/molecule/source-version/converge.yml
+++ b/molecule/source-version/converge.yml
@@ -4,7 +4,7 @@
   pre_tasks:
     - name: Set NGINX version
       ansible.builtin.set_fact:
-        ngx_version: 1.26.1
+        ngx_version: 1.27.2
         cacheable: true
   tasks:
     - name: Install NGINX from source

--- a/molecule/source-version/molecule.yml
+++ b/molecule/source-version/molecule.yml
@@ -93,6 +93,7 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -108,7 +109,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,16 +157,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-mantic
-    image: ubuntu:mantic
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-noble
-    image: ubuntu:noble
+  - name: ubuntu-oracular
+    image: ubuntu:oracular
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -93,6 +93,7 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -108,7 +109,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,16 +157,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-mantic
-    image: ubuntu:mantic
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-noble
-    image: ubuntu:noble
+  - name: ubuntu-oracular
+    image: ubuntu:oracular
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -93,6 +93,7 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -108,7 +109,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,16 +157,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-mantic
-    image: ubuntu:mantic
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-noble
-    image: ubuntu:noble
+  - name: ubuntu-oracular
+    image: ubuntu:oracular
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall-plus/molecule.yml
+++ b/molecule/uninstall-plus/molecule.yml
@@ -18,15 +18,6 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.16
-    image: alpine:3.16
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
@@ -45,6 +36,14 @@ platforms:
     command: /sbin/init
   - name: alpine-3.19
     image: alpine:3.19
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.20
+    image: alpine:3.20
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -94,6 +93,7 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -109,7 +109,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/uninstall-plus/prepare.yml
+++ b/molecule/uninstall-plus/prepare.yml
@@ -35,4 +35,5 @@
         nginx_license:
           certificate: license/nginx-repo.crt
           key: license/nginx-repo.key
-          jwt: license/license.jwt
+          jwt:
+            src: license/license.jwt

--- a/molecule/uninstall-plus/prepare.yml
+++ b/molecule/uninstall-plus/prepare.yml
@@ -17,6 +17,13 @@
         force: false
         mode: "0444"
 
+    - name: Create ephemeral license JWT file from b64 encoded env var
+      ansible.builtin.copy:
+        content: "{{ lookup('env', 'NGINX_JWT') }}"
+        dest: ../../files/license/license.jwt
+        force: false
+        mode: "0444"
+
 - name: Prepare NGINX Plus
   hosts: all
   tasks:
@@ -28,3 +35,4 @@
         nginx_license:
           certificate: license/nginx-repo.crt
           key: license/nginx-repo.key
+          jwt: license/license.jwt

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -93,6 +93,7 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -108,7 +109,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,16 +157,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-mantic
-    image: ubuntu:mantic
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-noble
-    image: ubuntu:noble
+  - name: ubuntu-oracular
+    image: ubuntu:oracular
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/molecule/upgrade-plus/converge.yml
+++ b/molecule/upgrade-plus/converge.yml
@@ -10,5 +10,6 @@
         nginx_license:
           certificate: license/nginx-repo.crt
           key: license/nginx-repo.key
+          jwt: license/license.jwt
         nginx_remove_license: false
         nginx_setup: upgrade

--- a/molecule/upgrade-plus/converge.yml
+++ b/molecule/upgrade-plus/converge.yml
@@ -10,6 +10,8 @@
         nginx_license:
           certificate: license/nginx-repo.crt
           key: license/nginx-repo.key
-          jwt: license/license.jwt
+          jwt:
+            src: license/license.jwt
+            dest: /etc/nginx/license.jwt
         nginx_remove_license: false
         nginx_setup: upgrade

--- a/molecule/upgrade-plus/molecule.yml
+++ b/molecule/upgrade-plus/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms: # Ubuntu noble only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
+platforms: # Alpine Linux 3.20 only has one version of NGINX Plus available (at the moment) so it's impossible to test the downgrade scenario
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -18,15 +18,6 @@ platforms: # Ubuntu noble only has one version of NGINX Plus available (at the m
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
-  - name: alpine-3.16
-    image: alpine:3.16
-    platform: x86_64
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: alpine-3.17
     image: alpine:3.17
     dockerfile: ../common/Dockerfile.j2
@@ -45,6 +36,14 @@ platforms: # Ubuntu noble only has one version of NGINX Plus available (at the m
     command: /sbin/init
   - name: alpine-3.19
     image: alpine:3.19
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
+  - name: alpine-3.20
+    image: alpine:3.20
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -94,6 +93,7 @@ platforms: # Ubuntu noble only has one version of NGINX Plus available (at the m
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -109,7 +109,7 @@ platforms: # Ubuntu noble only has one version of NGINX Plus available (at the m
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -157,14 +157,14 @@ platforms: # Ubuntu noble only has one version of NGINX Plus available (at the m
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: ubuntu-noble
-  #   image: ubuntu:noble
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: ubuntu-noble
+    image: ubuntu:noble
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/upgrade-plus/prepare.yml
+++ b/molecule/upgrade-plus/prepare.yml
@@ -17,24 +17,31 @@
         force: false
         mode: "0444"
 
+    - name: Create ephemeral license JWT file from b64 encoded env var
+      ansible.builtin.copy:
+        content: "{{ lookup('env', 'NGINX_JWT') }}"
+        dest: ../../files/license/license.jwt
+        force: false
+        mode: "0444"
+
 - name: Prepare NGINX Plus
   hosts: all
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =31-r1
+        version: =32-r1
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =31-1~{{ ansible_facts['distribution_release'] }}
+        version: =32-1~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -31-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -32-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =31-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =32-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
       when: ansible_facts['os_family'] == "Suse"
   tasks:
     - name: Install NGINX

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: docker
-platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the moment) so it's impossible to test the upgrade scenario
+platforms: # Ubuntu oracular only has one version of NGINX OSS available (at the moment) so it's impossible to test the upgrade scenario
   - name: almalinux-8
     image: almalinux:8
     dockerfile: ../common/Dockerfile.j2
@@ -42,14 +42,14 @@ platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the mom
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  # - name: alpine-3.20
-  #   image: alpine:3.20
-  #   dockerfile: ../common/Dockerfile.j2
-  #   privileged: true
-  #   cgroupns_mode: host
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #   command: /sbin/init
+  - name: alpine-3.20
+    image: alpine:3.20
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: amazonlinux-2
     image: amazonlinux:2
     platform: x86_64
@@ -93,6 +93,7 @@ platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the mom
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -108,7 +109,7 @@ platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the mom
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,14 +157,6 @@ platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the mom
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-mantic
-    image: ubuntu:mantic
-    dockerfile: ../common/Dockerfile.j2
-    privileged: true
-    cgroupns_mode: host
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    command: /sbin/init
   - name: ubuntu-noble
     image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
@@ -172,6 +165,14 @@ platforms: # Alpine 3.20 only has one version of NGINX OSS available (at the mom
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  # - name: ubuntu-oracular
+  #   image: ubuntu:oracular
+  #   dockerfile: ../common/Dockerfile.j2
+  #   privileged: true
+  #   cgroupns_mode: host
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  #   command: /sbin/init
 provisioner:
   name: ansible
   log: true

--- a/molecule/upgrade/prepare.yml
+++ b/molecule/upgrade/prepare.yml
@@ -4,19 +4,19 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        version: =1.25.5-r1
+        version: =1.27.1-r1
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =1.25.5-1~{{ ansible_facts['distribution_release'] }}
+        version: =1.27.1-1~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        version: -1.25.5-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        version: -1.27.1-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        version: =1.25.5-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        version: =1.27.1-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
       when: ansible_facts['os_family'] == "Suse"
   tasks:
     - name: Install NGINX

--- a/molecule/version/converge.yml
+++ b/molecule/version/converge.yml
@@ -4,26 +4,26 @@
   pre_tasks:
     - name: Set repo if Alpine
       ansible.builtin.set_fact:
-        ngx_version: =1.27.0-r2
-        njs_version: =1.27.0.0.8.5-r2
+        ngx_version: =1.27.2-r1
+        njs_version: =1.27.2.0.8.6-r1
         cacheable: true
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        ngx_version: =1.27.0-2~{{ ansible_facts['distribution_release'] }}
-        njs_version: =1.27.0+0.8.5-2~{{ ansible_facts['distribution_release'] }}
+        ngx_version: =1.27.2-1~{{ ansible_facts['distribution_release'] }}
+        njs_version: =1.27.2+0.8.6-1~{{ ansible_facts['distribution_release'] }}
         cacheable: true
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:
-        ngx_version: -1.27.0-2.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
-        njs_version: -1.27.0+0.8.5-2.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        ngx_version: -1.27.2-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
+        njs_version: -1.27.2+0.8.6-1.{{ (ansible_facts['distribution'] == "Amazon") | ternary(('amzn' + ansible_facts['distribution_major_version'] | string), ('el' + ansible_facts['distribution_major_version'] | string)) }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "RedHat"
     - name: Set repo if SLES
       ansible.builtin.set_fact:
-        ngx_version: =1.27.0-2.sles{{ ansible_facts['distribution_major_version'] }}.ngx
-        njs_version: =1.27.0+0.8.5-2.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        ngx_version: =1.27.2-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
+        njs_version: =1.27.2+0.8.6-1.sles{{ ansible_facts['distribution_major_version'] }}.ngx
         cacheable: true
       when: ansible_facts['os_family'] == "Suse"
   tasks:

--- a/molecule/version/molecule.yml
+++ b/molecule/version/molecule.yml
@@ -93,6 +93,7 @@ platforms:
     command: /usr/sbin/init
   - name: oraclelinux-9
     image: oraclelinux:9
+    platform: x86_64
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -108,7 +109,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /usr/sbin/init
   - name: rhel-9
-    image: redhat/ubi9:9.4
+    image: redhat/ubi9:9.5
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
@@ -156,16 +157,16 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-mantic
-    image: ubuntu:mantic
+  - name: ubuntu-noble
+    image: ubuntu:noble
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
-  - name: ubuntu-noble
-    image: ubuntu:noble
+  - name: ubuntu-oracular
+    image: ubuntu:oracular
     dockerfile: ../common/Dockerfile.j2
     privileged: true
     cgroupns_mode: host

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -44,6 +44,7 @@
       or not ((ansible_facts['os_family'] == 'Suse')
       or (ansible_facts['distribution'] == 'Amazon' and ansible_facts['distribution_major_version'] is version('2', '==')))
     - not (item['name'] | default(item) == 'lua')
-      or not (ansible_facts['architecture'] == 's390x')
+      or not ((ansible_facts['architecture'] == 's390x')
+      or (ansible_facts['os_family'] == 'Suse' and ansible_facts['distribution_major_version'] is version('12', '==')))
     - not (item['name'] | default(item) == 'opentracing')
       or not (ansible_facts['os_family'] == 'Suse' and ansible_facts['distribution_major_version'] is version('12', '=='))

--- a/tasks/plus/setup-license.yml
+++ b/tasks/plus/setup-license.yml
@@ -39,8 +39,8 @@
     - name: (Alpine Linux) Check that NGINX Plus license is valid
       ansible.builtin.assert:
         that:
-          - cert.expired == false
-          - cert.public_key == key.public_key
+          - cert['expired'] == false
+          - cert['public_key'] == key['public_key']
         success_msg: Your NGINX Plus license is valid!
         fail_msg: Something went wrong! Make sure your NGINX Plus license is valid!
 
@@ -88,8 +88,8 @@
     - name: (Debian/Red Hat/SLES OSs) Check that NGINX Plus license is valid
       ansible.builtin.assert:
         that:
-          - cert.expired == false
-          - cert.public_key == key.public_key
+          - cert['expired'] == false
+          - cert['public_key'] == key['public_key']
         success_msg: Your NGINX Plus license is valid!
         fail_msg: Something went wrong! Make sure your NGINX Plus license is valid!
 
@@ -107,3 +107,77 @@
             dest: /etc/ssl/nginx/nginx-repo-bundle.crt
             mode: "0444"
           when: not bundle['stat']['exists']
+
+- name: Set up NGINX Plus JWT
+  block:
+    - name: Check if NGINX Plus is being installed or upgraded
+      ansible.builtin.package_facts:
+
+    - name: Obtain version of NGINX Plus if it's already installed
+      when: "'nginx-plus' in ansible_facts['packages']"
+      block:
+        - name: Check NGINX Plus version
+          ansible.builtin.command: nginx -v
+          register: nginx_plus_version
+          changed_when: false
+
+        - name: Parse NGINX Plus version
+          ansible.builtin.set_fact:
+            nginx_plus_installed_version: "{{ nginx_plus_version['stderr'] | regex_search('nginx-plus-r(\\d+)', '\\1') | first }}"
+
+    - name: Obtain version of NGINX Plus to be installed (if set)
+      ansible.builtin.set_fact:
+        nginx_plus_target_version: "{{ nginx_version | regex_search('(\\d+)', '\\1') | first }}"
+      when: nginx_version is defined
+
+    - name: Set up JWT
+      when:
+        - nginx_setup in ['install', 'upgrade']
+        - nginx_plus_installed_version is defined and (nginx_setup == 'upgrade' or nginx_plus_target_version is defined and nginx_plus_target_version is version('33', '>='))
+          or nginx_plus_installed_version is not defined and (nginx_plus_target_version is not defined or nginx_plus_target_version is version('33', '>='))
+      block:
+        - name: Create NGINX Plus main directory
+          ansible.builtin.file:
+            path: /etc/nginx
+            state: directory
+            mode: "0755"
+
+        - name: Copy NGINX Plus JWT
+          ansible.builtin.copy:
+            src: "{{ nginx_license['jwt'] }}"
+            dest: /etc/nginx/license.jwt
+            decrypt: true
+            mode: "0444"
+
+        - name: Verify NGINX Plus JWT claims
+          block:
+            - name: Read JWT file
+              ansible.builtin.slurp:
+                src: /etc/nginx/license.jwt
+              register: jwt_file
+
+            - name: Decode JWT payload using base64url
+              ansible.builtin.set_fact:
+                jwt_payload_encoded: "{{ (jwt_file['content'] | b64decode | split('.'))[1] }}"
+
+            - name: Decode JWT payload using base64url
+              ansible.builtin.set_fact:
+                jwt_payload: >-
+                  {{
+                    jwt_payload_encoded
+                    | regex_replace('-', '+')
+                    | regex_replace('_', '/')
+                    | regex_replace('\s*$', '=' * (4 - jwt_payload_encoded | length % 4))
+                    | b64decode
+                    | from_json
+                  }}
+
+            - name: Assert JWT payload 'iss', 'aud', 'iat', and 'f5_sat' claims
+              ansible.builtin.assert:
+                that:
+                  - jwt_payload['iss'] == 'F5 Inc.'
+                  - jwt_payload['aud'] == 'urn:f5:teem'
+                  - (ansible_facts['date_time']['epoch'] | int) >= jwt_payload['iat']
+                  - (ansible_facts['date_time']['epoch'] | int) <= jwt_payload['f5_sat']
+                success_msg: 'JWT is valid'
+                fail_msg: 'JWT is invalid. Double check that the JWT data is correct.'

--- a/tasks/plus/setup-license.yml
+++ b/tasks/plus/setup-license.yml
@@ -144,8 +144,8 @@
 
         - name: Copy NGINX Plus JWT
           ansible.builtin.copy:
-            src: "{{ nginx_license['jwt'] }}"
-            dest: /etc/nginx/license.jwt
+            src: "{{ nginx_license['jwt']['src'] | default(nginx_license['jwt']) }}"
+            dest: "{{ nginx_license['jwt']['dest'] | default((ansible_facts['os_family'] == 'FreeBSD') | ternary('/usr/local/etc/nginx/license.jwt', '/etc/nginx/license.jwt')) }}"
             decrypt: true
             mode: "0444"
 
@@ -153,7 +153,7 @@
           block:
             - name: Read JWT file
               ansible.builtin.slurp:
-                src: /etc/nginx/license.jwt
+                src: "{{ nginx_license['jwt']['dest'] | default((ansible_facts['os_family'] == 'FreeBSD') | ternary('/usr/local/etc/nginx/license.jwt', '/etc/nginx/license.jwt')) }}"
               register: jwt_file
 
             - name: Decode JWT payload using base64url
@@ -179,5 +179,5 @@
                   - jwt_payload['aud'] == 'urn:f5:teem'
                   - (ansible_facts['date_time']['epoch'] | int) >= jwt_payload['iat']
                   - (ansible_facts['date_time']['epoch'] | int) <= jwt_payload['f5_sat']
-                success_msg: 'JWT is valid'
-                fail_msg: 'JWT is invalid. Double check that the JWT data is correct.'
+                success_msg: Your NGINX Plus license JWT is valid!
+                fail_msg: Something went wrong! Make sure your NGINX Plus license JWT is valid!

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -59,7 +59,7 @@ nginx_supported_distributions:
     architectures: [x86_64]
   ubuntu:
     name: Ubuntu
-    versions: [20.04, 22.04, 23.10, 24.04]
+    versions: [20.04, 22.04, 24.04, 24.10]
     architectures: "{{ ['x86_64', 'aarch64', 's390x'] if ((ansible_facts['distribution_version'] is version('20.04', '==')) or (ansible_facts['distribution_version'] is version('22.04', '=='))) else ['x86_64', 'aarch64'] }}"
 
 # Supported NGINX Plus distributions
@@ -71,7 +71,7 @@ nginx_plus_supported_distributions:
     architectures: [x86_64, aarch64]
   alpine:
     name: Alpine Linux
-    versions: [3.16, 3.17, 3.18, 3.19]
+    versions: [3.17, 3.18, 3.19, 3.20]
     architectures: [x86_64, aarch64]
   amazon:
     name: Amazon Linux
@@ -83,7 +83,7 @@ nginx_plus_supported_distributions:
     architectures: [x86_64, aarch64]
   freebsd:
     name: FreeBSD
-    versions: [12, 13, 14]
+    versions: [13, 14]
     architectures: [x86_64]
   oraclelinux:
     name: Oracle Linux
@@ -92,7 +92,7 @@ nginx_plus_supported_distributions:
   redhat:
     name: Red Hat Enterprise Linux
     versions: [8, 9]
-    architectures: "{{ ['x86_64', 'aarch64', 's390x'] if (ansible_facts['distribution_major_version'] is version('8', '>=')) else ['x86_64', 'aarch64'] }}"
+    architectures: [x86_64, aarch64]
   rocky:
     name: Rocky Linux
     versions: [8, 9]
@@ -104,7 +104,7 @@ nginx_plus_supported_distributions:
   ubuntu:
     name: Ubuntu
     versions: [20.04, 22.04, 24.04]
-    architectures: "{{ ['x86_64', 'aarch64', 's390x'] if ((ansible_facts['distribution_version'] is version('20.04', '==')) or (ansible_facts['distribution_version'] is version('22.04', '=='))) else ['x86_64', 'aarch64'] }}"
+    architectures: [x86_64, aarch64]
 
 # Default NGINX signing key
 nginx_default_signing_key_pgp: https://nginx.org/keys/nginx_signing.key
@@ -140,7 +140,7 @@ nginx_freebsd_dependencies: [security/ca_root_nss]
 nginx_redhat_dependencies: [ca-certificates]
 
 # SLES dependencies
-nginx_sles_dependencies: [ca-certificates]
+nginx_sles_dependencies: [ca-certificates, python3-rpm]
 
 # Default locations and versions when 'nginx_install_from' is set to 'source'.
 # Set 'pcre_release' to 1 to install PCRE 1, modify the 'openssl_version' to move back to 1.1.1.


### PR DESCRIPTION
### Proposed changes

This PR adds support for installing NGINX Plus using the JWT license that's required starting with R33. It also adds support for installing NGINX Plus on Alpine Linux 3.20 whilst removing support for installing NGINX Plus on Alpine Linux 3.16.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
