### PR TITLE
fix: Run Ansible versions validation tasks on check mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.25.1
+
+BUG FIXES:
+
+- Ansible and Jinja software versions validation tasks in ansible check mode.
+
 ## 0.25.0 (Nov 28, 2024)
 
 BREAKING CHANGES:

--- a/tasks/validate/validate.yml
+++ b/tasks/validate/validate.yml
@@ -15,6 +15,7 @@
   changed_when: false
   delegate_to: localhost
   become: false
+  check_mode: false
 
 - name: Verify that you are using a supported Jinja2 version on your Ansible host
   ansible.builtin.assert:
@@ -30,6 +31,7 @@
   changed_when: false
   delegate_to: localhost
   become: false
+  check_mode: false
 
 - name: Verify that the 'community.general' Ansible collection is installed on your Ansible host
   ansible.builtin.assert:


### PR DESCRIPTION
### Proposed changes

fix #840

Since a6712e391ab1a283cf24102a4055ea16fc756105, ansible and jinja versions are validated to ensure supported versions are used.
This validation is done by delegating `command` tasks to localhost, and parsing the standard output of the executed commands, e.g. `ansible --version`.

The `ansible.builtin.command` module is not run when in check mode, causing the variable which is supposed to get the result of the command to be empty, resulting in an error message in the following tasks that parse these result variables.

This commit ensures the `command` tasks are run even in check_mode. As they do no modification on localhost, this is not dangerous.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
