### PR TITLE
fix: Use `nginx_version` when installing NGINX modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 0.25.1
+## 0.25.1 (Unreleased)
 
 BUG FIXES:
 
-- Ansible and Jinja software versions validation tasks in ansible check mode.
+- Fix Ansible and Jinja versions validation tasks in ansible check mode.
+- Correctly use the `nginx_version` (if defined) for NGINX module versions.
 
 ## 0.25.0 (Nov 28, 2024)
 

--- a/molecule/version/converge.yml
+++ b/molecule/version/converge.yml
@@ -36,14 +36,12 @@
           - name: brotli
             version: "{{ ngx_version }}"
           - name: geoip
-            version: "{{ ngx_version }}"
           - name: image-filter
             version: "{{ ngx_version }}"
           - name: njs
             state: present
             version: "{{ njs_version }}"
           - name: perl
-            version: "{{ ngx_version }}"
           - name: xslt
             version: "{{ ngx_version }}"
         nginx_service_modify: true

--- a/tasks/modules/install-modules.yml
+++ b/tasks/modules/install-modules.yml
@@ -28,7 +28,7 @@
 - name: Install NGINX modules
   ansible.builtin.package:
     name: "nginx-{{ (nginx_type == 'plus') | ternary('plus-', '') }}module-{{ item['name'] | default(item) }}\
-          {{ (nginx_repository is not defined and ansible_facts['os_family'] == 'Alpine' and nginx_type != 'plus') | ternary('@nginx', '') }}{{ item['version'] | default('') }}"
+          {{ (nginx_repository is not defined and ansible_facts['os_family'] == 'Alpine' and nginx_type != 'plus') | ternary('@nginx', '') }}{{ item['version'] | default((nginx_version is defined) | ternary(nginx_version, '')) }}"
     state: "{{ item['state'] | default('present') }}"
   loop: "{{ nginx_modules }}"
   when:


### PR DESCRIPTION
### Proposed changes

Correctly use the `nginx_version` (if defined) for NGINX module versions. Fixes #861.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
