### PR TITLE
feat: Allow overriding distribution package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.25.1 (Unreleased)
 
+FEATURES:
+
+- Add a parameter, `nginx_distribution_package`, to override the default NGINX package when installing NGINX from your distribution/OS repository.
+
 BUG FIXES:
 
 - Fix Ansible and Jinja versions validation tasks in ansible check mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 FEATURES:
 
-- Add a parameter, `nginx_distribution_package`, to override the default NGINX package when installing NGINX from your distribution/OS repository.
+- Add a parameter, `nginx_distribution_package`, to override the default NGINX package name when installing NGINX from your distribution/OS repository.
 
 BUG FIXES:
 

--- a/defaults/main/main.yml
+++ b/defaults/main/main.yml
@@ -46,6 +46,11 @@ nginx_manage_repo: true
 # Default is nginx_repository.
 nginx_install_from: nginx_repository
 
+# (Optional) Specify repository for NGINX Open Source or NGINX Plus.
+# Only works if 'install_from' is set to 'nginx_repository' when installing NGINX Open Source.
+# Defaults are the official NGINX repositories.
+# nginx_repository: deb https://nginx.org/packages/mainline/debian/ buster nginx
+
 # Specify source install options for NGINX Open Source.
 # Options represent whether to install from source also or to install from packages (default).
 # These only apply if 'nginx_install_from' is set to 'source'.
@@ -57,21 +62,19 @@ nginx_install_source_pcre: false
 nginx_install_source_openssl: true
 nginx_install_source_zlib: false
 
-# Specify source install module for NGINX Open Source.
+# Specify source install modules for NGINX Open Source.
 # You can select any of the static modules listed on http://nginx.org/en/docs/configure.html.
 # Format is '--with-*' where '*' should be used as static module name in the list below. (see an example below).
 # Default is 'http_ssl_module'. (DO NOT remove it if you need SSL support).
 nginx_static_modules: [http_ssl_module]
 # nginx_static_modules: ['http_v2_module']  # Example for '--with-http_v2_module'
 
+# (Optional) Specify NGINX package name when installing nginx from an 'os_repository'.
+# nginx_distribution_package: @nginx:1.24/common
+
 # (Optional) Choose where to fetch the NGINX signing key from.
 # Default is the official NGINX signing key host.
 # nginx_signing_key: http://nginx.org/keys/nginx_signing.key
-
-# (Optional) Specify repository for NGINX Open Source or NGINX Plus.
-# Only works if 'install_from' is set to 'nginx_repository' when installing NGINX Open Source.
-# Defaults are the official NGINX repositories.
-# nginx_repository: deb https://nginx.org/packages/mainline/debian/ buster nginx
 
 # Specify which branch of NGINX Open Source you want to install.
 # Options are 'mainline' or 'stable'.

--- a/molecule/distribution/converge.yml
+++ b/molecule/distribution/converge.yml
@@ -12,4 +12,4 @@
         name: ansible-role-nginx
       vars:
         nginx_install_from: os_repository
-        nginx_distribution_name: "{{ nginx_package_name }}"
+        nginx_distribution_package: "{{ nginx_package_name }}"

--- a/molecule/distribution/converge.yml
+++ b/molecule/distribution/converge.yml
@@ -1,9 +1,15 @@
 ---
 - name: Converge
   hosts: all
+  pre_tasks:
+    - name: Set package name if Alpine
+      ansible.builtin.set_fact:
+        nginx_package_name: "@nginx:1.24/common"
+      when: ansible_facts['os_family'] == "Alpine"
   tasks:
     - name: Install NGINX
       ansible.builtin.include_role:
         name: ansible-role-nginx
       vars:
         nginx_install_from: os_repository
+        nginx_distribution_name: "{{ nginx_package_name }}"

--- a/molecule/distribution/converge.yml
+++ b/molecule/distribution/converge.yml
@@ -2,10 +2,10 @@
 - name: Converge
   hosts: all
   pre_tasks:
-    - name: Set package name if Alpine
+    - name: Set package name if Debian
       ansible.builtin.set_fact:
-        nginx_package_name: "@nginx:1.24/common"
-      when: ansible_facts['os_family'] == "Alpine"
+        nginx_package_name: nginx-core
+      when: ansible_facts['os_family'] == "Debian"
   tasks:
     - name: Install NGINX
       ansible.builtin.include_role:

--- a/molecule/distribution/verify.yml
+++ b/molecule/distribution/verify.yml
@@ -8,6 +8,16 @@
         state: present
       check_mode: true
       register: install
+      when: ansible_facts['os_family'] != 'Debian'
+      failed_when: (install is changed) or (install is failed)
+
+    - name: Check if NGINX is installed
+      ansible.builtin.package:
+        name: nginx-core
+        state: present
+      check_mode: true
+      register: install
+      when: ansible_facts['os_family'] == 'Debian'
       failed_when: (install is changed) or (install is failed)
 
     - name: Check if NGINX service is running

--- a/tasks/opensource/install-distribution.yml
+++ b/tasks/opensource/install-distribution.yml
@@ -9,6 +9,6 @@
 
 - name: "{{ nginx_setup | capitalize }} NGINX from the distribution's package repository"
   ansible.builtin.package:
-    name: nginx{{ nginx_version | default('') }}
+    name: "{{ nginx_distribution_package | default('nginx' + (nginx_version | default(''))) }}"
     state: "{{ nginx_state }}"
   notify: (Handler) Run NGINX


### PR DESCRIPTION
### Proposed changes

Add a parameter, `nginx_distribution_package`, to override the default NGINX package name when installing NGINX from your distribution/OS repository. Supersedes #857.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
