### PR TITLE
fix #906: prevent false-negative on check in dry-run mode

### DIFF
--- a/tasks/validate/validate.yml
+++ b/tasks/validate/validate.yml
@@ -14,6 +14,7 @@
   register: jinja2_version
   changed_when: false
   delegate_to: localhost
+  check_mode: no
   become: false
   check_mode: false
 
@@ -30,6 +31,7 @@
   register: collection_list
   changed_when: false
   delegate_to: localhost
+  check_mode: no
   become: false
   check_mode: false
 


### PR DESCRIPTION
### Proposed changes

This PR resolves a false-negative failure that occurs in `--check` (dry-run) mode when validating environment compatibility.

Specifically, two delegated tasks:

- Extract the version of Jinja2 installed on your Ansible host
- Extract the list of Ansible collections installed on your Ansible host

use `ansible.builtin.command` with `delegate_to: localhost` and `register`, but do not explicitly disable check-mode.

In dry-run mode, these tasks are silently skipped, leaving the registered variables empty and causing downstream `assert` tasks to fail — even when the environment is valid.

This PR adds `check_mode: no` to both command tasks, ensuring they run in dry-run mode as well. These are harmless, read-only queries that are safe in all execution modes.

Fixes #906

### Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [ ] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [ ] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
