### PR TITLE
fix(logrotate): handler no longer fails if all errors are about skipping rotation

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -59,7 +59,7 @@
 
 - name: (Handler) Print logrotate error if config check fails
   ansible.builtin.debug:
-    var: logrotate_check['stderr_lines']
+    var: logrotate_check['stderr_lines'] and logrotate_check['stderr_lines'] | select('search','already exists, skipping rotation$') != logrotate_check['stderr_lines']
   failed_when: logrotate_check['rc'] != 0
   when:
     - logrotate_check['stderr_lines'] is defined

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -59,8 +59,8 @@
 
 - name: (Handler) Print logrotate error if config check fails
   ansible.builtin.debug:
-    var: logrotate_check['stderr_lines'] and logrotate_check['stderr_lines'] | select('search','already exists, skipping rotation$') != logrotate_check['stderr_lines']
-  failed_when: logrotate_check['rc'] != 0
+    var: logrotate_check['stderr_lines']
+  failed_when: logrotate_check['rc'] != 0 and logrotate_check['stderr_lines'] | select('search','already exists, skipping rotation$') != logrotate_check['stderr_lines']
   when:
     - logrotate_check['stderr_lines'] is defined
     - logrotate_check['stderr_lines'] != []


### PR DESCRIPTION
### Proposed changes

The print logrotate error handler no longer fails if *all* errors are about rotation failing due to preexisting log files.  If any of the errors are about something else, failure will occur as usual.

This resolves #913

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [X] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [X] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [X] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
