### PR TITLE
feat(systemd): Manage `After` dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ FEATURES:
 - Add support for installing NGINX Open Source and NGINX Plus on Alpine Linux 3.21.
 - Add a parameter, `nginx_distribution_package`, to override the default NGINX package name when installing NGINX from your distribution/OS repository.
 - Add a parameter, `nginx_skip_os_install_config_check`, to turn off the NGINX config check handler when installing NGINX from the respective distribution package manager. This should help avoid potential issues where the default NGINX config that ships with a distribution is broken for some reason.
+- Add a parameter, `nginx_service_after`, to start the service after this list of systemd units.
 
 BUG FIXES:
 

--- a/defaults/main/systemd.yml
+++ b/defaults/main/systemd.yml
@@ -35,6 +35,12 @@ nginx_service_overridefilename: override.conf
 # Default is to comment this out
 # nginx_service_restartsec: 5s
 
+# Start the service after these units
+# [Unit]
+# After=
+# Default is to comment this out
+# nginx_service_after: []
+
 # Enable a custom systemd override file
 # ** This could break the service **
 # Setting this to true disables custom values above

--- a/templates/services/nginx.service.override.conf.j2
+++ b/templates/services/nginx.service.override.conf.j2
@@ -16,3 +16,8 @@ Restart={{ nginx_service_restart }}
 {% if nginx_service_restartsec is defined %}
 RestartSec={{ nginx_service_restartsec }}
 {% endif %}
+
+[Unit]
+{% if nginx_service_after %}
+After={{ nginx_service_after | join(" ") }}
+{% endif %}


### PR DESCRIPTION
Allow nginx to be started after a list of systemd units (disabled by default).

### Proposed changes

If nginx is listening to a tailscale IP address, the tailscaled.service unit must be started (and the IP address must be assigned) before starting nginx. Otherwise, the service will fail to start and the service will not survive a reboot. This commit allows to define `nginx_service_after` variable to eventually add a list of units separated by whitespaces.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
