### PR TITLE
feat: Reduce "changed" strings in output

### DIFF
--- a/tasks/validate/validate.yml
+++ b/tasks/validate/validate.yml
@@ -6,6 +6,7 @@
       - ansible_version['full'] is version('2.18', '<')
     success_msg: Ansible {{ ansible_version['full'] }} is supported.
     fail_msg: ({{ ansible_version['full'] is version('2.18', '>=') }} | ternary('Ansible {{ ansible_version['full'] }} is not yet supported. Please downgrade to a supported Ansible release', 'Ansible {{ ansible_version['full'] }} has reached End of Life (EoL). Please upgrade to a supported Ansible release.') Check the README for more details.
+    quiet: true
   delegate_to: localhost
   ignore_errors: true # noqa ignore-errors
 
@@ -22,6 +23,7 @@
     that: (jinja2_version['stdout'] | regex_search('jinja version = ([\\d.]+)', '\\1') | first) is version(nginx_jinja2_version, '>=')
     success_msg: Jinja2 {{ jinja2_version['stdout'] | regex_search('jinja version = ([\d.]+)', '\1') | first }} is supported.
     fail_msg: Jinja2 {{ jinja2_version['stdout'] | regex_search('jinja version = ([\d.]+)', '\1') | first }} is not supported. Please upgrade to Jinja2 3.1. Check the README for more details.
+    quiet: true
   delegate_to: localhost
   become: false
 
@@ -38,6 +40,7 @@
     that: collection_list is search('community.general')
     success_msg: The 'community.general' Ansible collection is installed.
     fail_msg: The 'community.general' Ansible collection is not installed. Please install the 'community.general' Ansible collection. Check the README for more details.
+    quiet: true
   delegate_to: localhost
   become: false
 
@@ -46,6 +49,7 @@
     that: lookup('community.general.collection_version', 'ansible.posix') != 'none'
     success_msg: The 'ansible.posix' Ansible collection is installed.
     fail_msg: The 'ansible.posix' Ansible collection is not installed. Please install the 'ansible.posix' Ansible collection. Check the README for more details.
+    quiet: true
   when: nginx_selinux | bool
   delegate_to: localhost
   become: false
@@ -55,6 +59,7 @@
     that: lookup('community.general.collection_version', 'community.crypto') != 'none'
     success_msg: The 'community.crypto' Ansible collection is installed.
     fail_msg: The 'community.crypto' Ansible collection is not installed. Please install the 'community.crypto' Ansible collection. Check the README for more details.
+    quiet: true
   when: nginx_type == 'plus'
   delegate_to: localhost
   become: false
@@ -64,6 +69,7 @@
     that: nginx_setup in nginx_setup_vars
     success_msg: The value you used for 'nginx_setup', {{ nginx_setup }}, is valid.
     fail_msg: The value you used for 'nginx_setup', {{ nginx_setup }}, is not valid. The valid values are [{{ nginx_setup_vars | join(', ') }}].
+    quiet: true
   when: nginx_enable | bool
   delegate_to: localhost
   become: false
@@ -74,6 +80,7 @@
     that: nginx_branch in nginx_branch_vars
     success_msg: The value you used for 'nginx_branch', {{ nginx_branch }}, is valid.
     fail_msg: The value you used for 'nginx_branch', {{ nginx_branch }}, is not allowed. The valid values are [{{ nginx_branch_vars | join(', ') }}].
+    quiet: true
   when: nginx_enable | bool
   delegate_to: localhost
   become: false
@@ -84,6 +91,7 @@
     that: nginx_install_from in nginx_install_from_vars
     success_msg: The value you used for 'nginx_install_from', {{ nginx_install_from }} is valid.
     fail_msg: The value you used for 'nginx_install_from', {{ nginx_install_from }}, is not valid. The valid values are [{{ nginx_install_from_vars | join(', ') }}].
+    quiet: true
   when: nginx_enable | bool
   delegate_to: localhost
   become: false
@@ -97,6 +105,7 @@
       - ansible_facts['architecture'] in nginx_distributions[ansible_facts['distribution'] | lower]['architectures']
     success_msg: Your distribution, {{ nginx_distributions[ansible_facts['distribution'] | lower]['name'] }} {{ ansible_facts['distribution_version'] }} ({{ ansible_facts['architecture'] }}), is supported by NGINX {{ (nginx_type == 'opensource') | ternary('Open Source', 'Plus') }}.
     fail_msg: Your distribution, {{ nginx_distributions[ansible_facts['distribution'] | lower]['name'] }} {{ ansible_facts['distribution_version'] }} ({{ ansible_facts['architecture'] }}), is not supported by NGINX {{ (nginx_type == 'opensource') | ternary('Open Source', 'Plus') }}.
+    quiet: true
   when:
     - nginx_enable | bool
     - (nginx_install_from == "nginx_repository" or nginx_type == "plus")
@@ -107,6 +116,7 @@
     that: (nginx_modules | difference(nginx_modules_list) == [] if nginx_type == 'opensource') or (nginx_modules | difference(nginx_plus_modules_list) == [] if nginx_type == 'plus')
     success_msg: The NGINX module(s) you are installing are supported.
     fail_msg: The NGINX module(s) you are installing are not supported. Please check the README for more details.
+    quiet: true
   when:
     - nginx_enable | bool
     - nginx_modules is defined


### PR DESCRIPTION
### Proposed changes

The impetus for this change is that having the string "changed" in the output makes it annoying to run check mode and then do a find for "changed" to figure out what a real run would modify.

Notice that, while the `success_msg` is no longer printed on success, the assertion _failure_ formatting is still similar to what's printed before (though I would argue it's not great already... `fail_msg` doesn't really print right). IMO given the fact that Ansible prints task names, the `success_msg` isn't really adding much here, so this behavior seems ok.

Before:

```
[snipped]
TASK [nginxinc.nginx : Validate Ansible/Jinja2 version, Ansible collections, role variables, and supported distributions] ***************************************************
included: /var/home/alex/.ansible/roles/nginxinc.nginx/tasks/validate/validate.yml for dokku.host.seagl.org

TASK [nginxinc.nginx : Verify you are using a supported Ansible version on your Ansible host] *******************************************************************************
fatal: [dokku.host.seagl.org -> localhost]: FAILED! => {
    "assertion": "ansible_version['full'] is version('2.18', '<')",
    "changed": false,
    "evaluated_to": false,
    "msg": "(True | ternary('Ansible 2.18.11 is not yet supported. Please downgrade to a supported Ansible release', 'Ansible 2.18.11 has reached End of Life (EoL). Please upgrade to a supported Ansible release.') Check the README for more details."
}
...ignoring

TASK [nginxinc.nginx : Extract the version of Jinja2 installed on your Ansible host] ****************************************************************************************
ok: [dokku.host.seagl.org -> localhost]

TASK [nginxinc.nginx : Verify that you are using a supported Jinja2 version on your Ansible host] ***************************************************************************
ok: [dokku.host.seagl.org -> localhost] => {
    "changed": false,
    "msg": "Jinja2 3.1.6 is supported."
}

TASK [nginxinc.nginx : Extract the list of Ansible collections installed on your Ansible host] ******************************************************************************
ok: [dokku.host.seagl.org -> localhost]

TASK [nginxinc.nginx : Verify that the 'community.general' Ansible collection is installed on your Ansible host] ************************************************************
ok: [dokku.host.seagl.org -> localhost] => {
    "changed": false,
    "msg": "The 'community.general' Ansible collection is installed."
}

TASK [nginxinc.nginx : Verify that the 'ansible.posix' Ansible collection is installed on your Ansible host] ****************************************************************
skipping: [dokku.host.seagl.org]

TASK [nginxinc.nginx : Verify that the 'community.crypto' Ansible collection is installed on your Ansible host] *************************************************************
skipping: [dokku.host.seagl.org]

TASK [nginxinc.nginx : Verify that 'nginx_setup' parameter is a valid value] ************************************************************************************************
ok: [dokku.host.seagl.org -> localhost] => {
    "changed": false,
    "msg": "The value you used for 'nginx_setup', install, is valid."
}

TASK [nginxinc.nginx : Verify that 'nginx_branch' parameter is a valid value] ***********************************************************************************************
ok: [dokku.host.seagl.org -> localhost] => {
    "changed": false,
    "msg": "The value you used for 'nginx_branch', mainline, is valid."
}

TASK [nginxinc.nginx : Verify that 'nginx_install_from' parameter is a valid value] *****************************************************************************************
ok: [dokku.host.seagl.org -> localhost] => {
    "changed": false,
    "msg": "The value you used for 'nginx_install_from', nginx_repository is valid."
}

TASK [nginxinc.nginx : Verify whether you are using a supported NGINX distribution] *****************************************************************************************
ok: [dokku.host.seagl.org] => {
    "changed": false,
    "msg": "Your distribution, Ubuntu 24.04 (x86_64), is supported by NGINX Open Source."
}

TASK [nginxinc.nginx : Verify that you are installing a supported NGINX dynamic module] *************************************************************************************
skipping: [dokku.host.seagl.org]

[snipped]
```

After:

```
[snipped]
TASK [nginxinc.nginx : Validate Ansible/Jinja2 version, Ansible collections, role variables, and supported distributions] ***************************************************
included: /var/home/alex/.ansible/roles/nginxinc.nginx/tasks/validate/validate.yml for dokku.host.seagl.org

TASK [nginxinc.nginx : Verify you are using a supported Ansible version on your Ansible host] *******************************************************************************
fatal: [dokku.host.seagl.org -> localhost]: FAILED! => {"assertion": "ansible_version['full'] is version('2.18', '<')", "changed": false, "evaluated_to": false, "msg": "(True | ternary('Ansible 2.18.11 is not yet supported. Please downgrade to a supported Ansible release', 'Ansible 2.18.11 has reached End of Life (EoL). Please upgrade to a supported Ansible release.') Check the README for more details."}
...ignoring

TASK [nginxinc.nginx : Extract the version of Jinja2 installed on your Ansible host] ****************************************************************************************
ok: [dokku.host.seagl.org -> localhost]

TASK [nginxinc.nginx : Verify that you are using a supported Jinja2 version on your Ansible host] ***************************************************************************
ok: [dokku.host.seagl.org -> localhost]

TASK [nginxinc.nginx : Extract the list of Ansible collections installed on your Ansible host] ******************************************************************************
ok: [dokku.host.seagl.org -> localhost]

TASK [nginxinc.nginx : Verify that the 'community.general' Ansible collection is installed on your Ansible host] ************************************************************
ok: [dokku.host.seagl.org -> localhost]

TASK [nginxinc.nginx : Verify that the 'ansible.posix' Ansible collection is installed on your Ansible host] ****************************************************************
skipping: [dokku.host.seagl.org]

TASK [nginxinc.nginx : Verify that the 'community.crypto' Ansible collection is installed on your Ansible host] *************************************************************
skipping: [dokku.host.seagl.org]

TASK [nginxinc.nginx : Verify that 'nginx_setup' parameter is a valid value] ************************************************************************************************
ok: [dokku.host.seagl.org -> localhost]

TASK [nginxinc.nginx : Verify that 'nginx_branch' parameter is a valid value] ***********************************************************************************************
ok: [dokku.host.seagl.org -> localhost]

TASK [nginxinc.nginx : Verify that 'nginx_install_from' parameter is a valid value] *****************************************************************************************
ok: [dokku.host.seagl.org -> localhost]

TASK [nginxinc.nginx : Verify whether you are using a supported NGINX distribution] *****************************************************************************************
ok: [dokku.host.seagl.org]

TASK [nginxinc.nginx : Verify that you are installing a supported NGINX dynamic module] *************************************************************************************
skipping: [dokku.host.seagl.org]

[snipped]
```

### Additional notes

I didn't run Molecule locally because this seemed so trivial that I figured I'd let CI take that job. Also, I did not adjust CHANGELOG.md because I was confused, see #926. Happy to amend the patch though, to add a changelog entry.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added Molecule tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant Molecule tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`defaults/main/*.yml`](/defaults/main/), [`README.md`](/README.md) and [`CHANGELOG.md`](/CHANGELOG.md)).
