### PR TITLE
Add support for Debian 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ BREAKING CHANGES:
 FEATURES:
 
 - Add support for installing NGINX Open Source and NGINX Plus on Alpine Linux 3.21.
+- Add support for installing NGINX Open Source and NGINX Plus on Debian 13 "trixie".
 - Add a parameter, `nginx_distribution_package`, to override the default NGINX package name when installing NGINX from your distribution/OS repository.
 - Add a parameter, `nginx_skip_os_install_config_check`, to turn off the NGINX config check handler when installing NGINX from the respective distribution package manager. This should help avoid potential issues where the default NGINX config that ships with a distribution is broken for some reason.
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Amazon Linux:
 Debian:
   - bullseye (11)
   - bookworm (12)
+  - trixie (13)
 Oracle Linux:
   - 8
   - 9

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Amazon Linux:
 Debian:
   - bullseye (11)
   - bookworm (12)
+  - trixie (13)
 Oracle Linux:
   - 8
   - 9
@@ -218,6 +219,7 @@ Amazon Linux:
 Debian:
   - bullseye (11)
   - bookworm (12)
+  - trixie (13)
 FreeBSD:
   - 13
   - 14

--- a/molecule/agent/molecule.yml
+++ b/molecule/agent/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/distribution/molecule.yml
+++ b/molecule/distribution/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/downgrade-plus/converge.yml
+++ b/molecule/downgrade-plus/converge.yml
@@ -9,7 +9,7 @@
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =32-1~{{ ansible_facts['distribution_release'] }}
+        version: =36-6~{{ ansible_facts['distribution_release'] }}
         cacheable: true
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat

--- a/molecule/downgrade-plus/converge.yml
+++ b/molecule/downgrade-plus/converge.yml
@@ -31,5 +31,6 @@
         nginx_license:
           certificate: license/nginx-repo.crt
           key: license/nginx-repo.key
+          jwt: license/license.jwt
         nginx_remove_license: false
         nginx_version: "{{ version }}"

--- a/molecule/downgrade-plus/molecule.yml
+++ b/molecule/downgrade-plus/molecule.yml
@@ -59,6 +59,14 @@ platforms: # Alpine Linux 3.21 only has one version of NGINX Plus available (at 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/downgrade/converge.yml
+++ b/molecule/downgrade/converge.yml
@@ -9,7 +9,7 @@
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =1.27.4-1~{{ ansible_facts['distribution_release'] }}
+        version: =1.29.2-1~{{ ansible_facts['distribution_release'] }}
         cacheable: true
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat

--- a/molecule/downgrade/molecule.yml
+++ b/molecule/downgrade/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/plus/molecule.yml
+++ b/molecule/plus/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/source-version/molecule.yml
+++ b/molecule/source-version/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/stable/molecule.yml
+++ b/molecule/stable/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/uninstall-plus/molecule.yml
+++ b/molecule/uninstall-plus/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/uninstall/molecule.yml
+++ b/molecule/uninstall/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/upgrade-plus/molecule.yml
+++ b/molecule/upgrade-plus/molecule.yml
@@ -59,6 +59,14 @@ platforms: # Alpine Linux 3.21 only has one version of NGINX Plus available (at 
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/upgrade-plus/prepare.yml
+++ b/molecule/upgrade-plus/prepare.yml
@@ -33,7 +33,7 @@
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =32-1~{{ ansible_facts['distribution_release'] }}
+        version: =36-6~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:

--- a/molecule/upgrade-plus/prepare.yml
+++ b/molecule/upgrade-plus/prepare.yml
@@ -52,4 +52,5 @@
         nginx_license:
           certificate: license/nginx-repo.crt
           key: license/nginx-repo.key
+          jwt: license/license.jwt
         nginx_version: "{{ version }}"

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/molecule/upgrade/prepare.yml
+++ b/molecule/upgrade/prepare.yml
@@ -8,7 +8,7 @@
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        version: =1.27.4-1~{{ ansible_facts['distribution_release'] }}
+        version: =1.29.2-1~{{ ansible_facts['distribution_release'] }}
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat
       ansible.builtin.set_fact:

--- a/molecule/version/converge.yml
+++ b/molecule/version/converge.yml
@@ -10,8 +10,8 @@
       when: ansible_facts['os_family'] == "Alpine"
     - name: Set repo if Debian
       ansible.builtin.set_fact:
-        ngx_version: =1.27.4-1~{{ ansible_facts['distribution_release'] }}
-        njs_version: =1.27.4+0.8.10-1~{{ ansible_facts['distribution_release'] }}
+        ngx_version: =1.29.2-1~{{ ansible_facts['distribution_release'] }}
+        njs_version: =1.29.2+0.9.3-1~{{ ansible_facts['distribution_release'] }}
         cacheable: true
       when: ansible_facts['os_family'] == "Debian"
     - name: Set repo if Red Hat

--- a/molecule/version/molecule.yml
+++ b/molecule/version/molecule.yml
@@ -59,6 +59,14 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     command: /sbin/init
+  - name: debian-trixie
+    image: debian:trixie-slim
+    dockerfile: ../common/Dockerfile.j2
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: /sbin/init
   - name: oraclelinux-8
     image: oraclelinux:8
     dockerfile: ../common/Dockerfile.j2

--- a/tasks/agent/setup-debian.yml
+++ b/tasks/agent/setup-debian.yml
@@ -2,6 +2,6 @@
 - name: (Debian/Ubuntu) Configure NGINX Agent repository
   ansible.builtin.apt_repository:
     filename: nginx-agent
-    repo: deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://packages.nginx.org/nginx-agent/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] | lower }} agent
+    repo: deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg.asc] https://packages.nginx.org/nginx-agent/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] | lower }} agent
     update_cache: true
     mode: "0644"

--- a/tasks/keys/setup-keys.yml
+++ b/tasks/keys/setup-keys.yml
@@ -18,10 +18,10 @@
   when: ansible_facts['os_family'] != 'Alpine'
 
 - name: (Debian/Ubuntu) Add NGINX signing key
-  ansible.builtin.apt_key:
-    id: 8540A6F18833A80E9C1653A42FD21310B49F6B46
-    keyring: /usr/share/keyrings/nginx-archive-keyring.gpg
+  ansible.builtin.get_url:
     url: "{{ keysite }}"
+    dest: /usr/share/keyrings/nginx-archive-keyring.gpg
+    checksum: sha256:55385da31d198fa6a5012d40ae98ecb272a6c4e8fffffba94719ffd3e87de37a
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: (Red Hat/SLES OSs) Add NGINX signing key

--- a/tasks/keys/setup-keys.yml
+++ b/tasks/keys/setup-keys.yml
@@ -20,7 +20,7 @@
 - name: (Debian/Ubuntu) Add NGINX signing key
   ansible.builtin.get_url:
     url: "{{ keysite }}"
-    dest: /usr/share/keyrings/nginx-archive-keyring.gpg
+    dest: /usr/share/keyrings/nginx-archive-keyring.gpg.asc
     checksum: sha256:55385da31d198fa6a5012d40ae98ecb272a6c4e8fffffba94719ffd3e87de37a
     mode: '0644'
   when: ansible_facts['os_family'] == 'Debian'

--- a/tasks/keys/setup-keys.yml
+++ b/tasks/keys/setup-keys.yml
@@ -22,6 +22,7 @@
     url: "{{ keysite }}"
     dest: /usr/share/keyrings/nginx-archive-keyring.gpg
     checksum: sha256:55385da31d198fa6a5012d40ae98ecb272a6c4e8fffffba94719ffd3e87de37a
+    mode: '0644'
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: (Red Hat/SLES OSs) Add NGINX signing key

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -114,8 +114,8 @@ nginx_default_signing_key_rsa_pub: https://nginx.org/keys/nginx_signing.rsa.pub
 nginx_default_repository_alpine: "@nginx https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}alpine/v{{ ansible_facts['distribution_version'] | regex_search('^[0-9]+\\.[0-9]+') }}/main"
 nginx_default_repository_amazon: https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}/amzn{{ (ansible_facts['distribution_major_version'] is version('2', '==')) | ternary('2/$releasever', '/2023') }}/$basearch
 nginx_default_repository_debian:
-  - deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}{{ ansible_facts['distribution'] | lower }}/ {{ ansible_facts['distribution_release'] }} nginx
-  - deb-src [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}{{ ansible_facts['distribution'] | lower }}/ {{ ansible_facts['distribution_release'] }} nginx
+  - deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg.asc] https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}{{ ansible_facts['distribution'] | lower }}/ {{ ansible_facts['distribution_release'] }} nginx
+  - deb-src [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg.asc] https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}{{ ansible_facts['distribution'] | lower }}/ {{ ansible_facts['distribution_release'] }} nginx
 nginx_default_repository_redhat: https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}rhel/{{ ansible_facts['distribution_major_version'] }}/$basearch
 nginx_default_repository_suse: https://nginx.org/packages/{{ (nginx_branch == 'mainline') | ternary('mainline/', '') }}sles/{{ ansible_facts['distribution_major_version'] }}
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -39,7 +39,7 @@ nginx_supported_distributions:
     architectures: [x86_64, aarch64]
   debian:
     name: Debian
-    versions: [11, 12]
+    versions: [11, 12, 13]
     architectures: [x86_64, aarch64]
   oraclelinux:
     name: Oracle Linux

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -79,7 +79,7 @@ nginx_plus_supported_distributions:
     architectures: [x86_64, aarch64]
   debian:
     name: Debian
-    versions: [11, 12]
+    versions: [11, 12, 13]
     architectures: [x86_64, aarch64]
   freebsd:
     name: FreeBSD

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -122,7 +122,7 @@ nginx_default_repository_suse: https://nginx.org/packages/{{ (nginx_branch == 'm
 # Default NGINX Plus repositories
 nginx_plus_default_repository_alpine: https://pkgs.nginx.com/plus/alpine/v{{ ansible_facts['distribution_version'] | regex_search('^[0-9]+\.[0-9]+') }}/main
 nginx_plus_default_repository_amazon: https://pkgs.nginx.com/plus/amzn{{ (ansible_facts['distribution_major_version'] is version('2', '==')) | ternary('2/$releasever', '/2023') }}/$basearch
-nginx_plus_default_repository_debian: deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] }} nginx-plus
+nginx_plus_default_repository_debian: deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg.asc] https://pkgs.nginx.com/plus/{{ ansible_facts['distribution'] | lower }} {{ ansible_facts['distribution_release'] }} nginx-plus
 nginx_plus_default_repository_freebsd: https://pkgs.nginx.com/plus/freebsd/${ABI}/latest
 nginx_plus_default_repository_redhat: https://pkgs.nginx.com/plus/rhel/{{ ansible_facts['distribution_major_version'] }}/$basearch
 nginx_plus_default_repository_suse: https://pkgs.nginx.com/plus/sles/{{ ansible_facts['distribution_major_version'] }}?ssl_clientcert=/etc/ssl/nginx/nginx-repo-bundle.crt&ssl_verify=peer


### PR DESCRIPTION
### Proposed changes

This PR adds support for Debian 13 in the ansible role for nginx.  Relevant commits grabbed from https://github.com/nginx/ansible-role-nginx/pull/916
